### PR TITLE
hisparse-mtp-without-h2d

### DIFF
--- a/python/sglang/jit_kernel/csrc/hisparse.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse.cuh
@@ -69,23 +69,85 @@ __device__ __forceinline__ int warp_inclusive_scan(int* s_data, int lane_id, int
   return accumulator;
 }
 
+template <int HOT_BUFFER_SIZE, bool IsDsv4Layout>
+__device__ __forceinline__ bool try_get_static_device_loc(
+    int32_t token_idx,
+    const int32_t* __restrict__ req_device_buffer_locs,
+    int64_t page_size,
+    int32_t* __restrict__ out_loc) {
+  if constexpr (IsDsv4Layout) {
+    return false;
+  } else {
+    if (token_idx < 0 || token_idx >= HOT_BUFFER_SIZE) {
+      return false;
+    }
+    const int32_t loc = req_device_buffer_locs[token_idx];
+    if (loc < 0) {
+      return false;
+    }
+    *out_loc = loc;
+    return true;
+  }
+}
+
+template <int HOT_BUFFER_SIZE, bool IsDsv4Layout>
+__device__ __forceinline__ bool try_get_extra_page_device_loc(
+    int32_t token_idx,
+    int64_t seq_len,
+    int64_t step,
+    int64_t num_steps,
+    const int32_t* __restrict__ req_device_buffer_tokens,
+    const int32_t* __restrict__ req_device_buffer_locs,
+    int64_t page_size,
+    int32_t* __restrict__ out_loc) {
+  int64_t slot = -1;
+  if constexpr (IsDsv4Layout) {
+    if (token_idx == seq_len - 1) {
+      slot = HOT_BUFFER_SIZE;
+    }
+  } else if (num_steps > 1) {
+    for (int64_t candidate_slot = HOT_BUFFER_SIZE; candidate_slot < HOT_BUFFER_SIZE + page_size; candidate_slot++) {
+      if (req_device_buffer_tokens[candidate_slot] == token_idx) {
+        slot = candidate_slot;
+        break;
+      }
+    }
+  } else if (token_idx == seq_len - 1) {
+    slot = HOT_BUFFER_SIZE;
+  }
+
+  if (slot < HOT_BUFFER_SIZE || slot >= HOT_BUFFER_SIZE + page_size) {
+    return false;
+  }
+  const int32_t loc = req_device_buffer_locs[slot];
+  if (loc < 0) {
+    return false;
+  }
+  *out_loc = loc;
+  return true;
+}
+
 // Shared memory size calculation for dynamic allocation.
 // Layout: int32_t region (4-byte aligned) followed by int16_t region (2-byte aligned).
 template <int NUM_TOP_K, int HOT_BUFFER_SIZE>
 struct SmemLayout {
   static constexpr int HASH_SIZE = NUM_TOP_K * 2;
   static constexpr int NUM_BUFFER_CHUNKS = (HOT_BUFFER_SIZE + WARP_SIZE - 1) / WARP_SIZE;
-  // int32_t region: top_k_tokens + chunk_offset + evict_chunk_offset + hash_keys + total_hits + newest_hit
-  static constexpr int TOTAL_INT32 = NUM_TOP_K + (NUM_BUFFER_CHUNKS + 1) + (NUM_BUFFER_CHUNKS + 1) + HASH_SIZE + 2;
+  // int32_t region: top_k_tokens + chunk offsets + evict offsets + hash keys + scalar counters.
+  static constexpr int TOTAL_INT32 = NUM_TOP_K + (NUM_BUFFER_CHUNKS + 1) + (NUM_BUFFER_CHUNKS + 1) + HASH_SIZE + 3;
   // int16_t region: lru_slots_out + hash_vals
   static constexpr int TOTAL_INT16 = HOT_BUFFER_SIZE + HASH_SIZE;
   static constexpr size_t BYTES = TOTAL_INT32 * sizeof(int32_t) + TOTAL_INT16 * sizeof(int16_t);
 };
 
-// Each block processes one request
+// Each block processes one request, looping over num_steps speculative steps.
 // req_pool_indices and seq_lens can each be int32_t or int64_t
 // Layout: [HOT_BUFFER_SIZE slots for LRU] + [page_size slots for newest token]
 // newest_slot is at HOT_BUFFER_SIZE (first position of extra page)
+//
+// Multi-step: top_k_tokens and top_k_device_locs are [num_reqs, num_steps, NUM_TOP_K]
+// (req-major). seq_lens is [num_reqs * num_steps] flat req-major. LRU state is
+// maintained across steps within each block for cross-step cache reuse.
 //
 // IsDsv4Layout selects the miss-copy addressing:
 //   false -> generic byte-stride: device + host both linear, stride = item_size_bytes
@@ -118,15 +180,14 @@ __global__ void load_cache_to_device_buffer_kernel(
     int64_t top_k_tokens_stride,
     int64_t top_k_device_locs_stride,
     int64_t page_size,
-    int64_t item_size_bytes) {
+    int64_t item_size_bytes,
+    int64_t num_steps) {
   static_assert(!IsDsv4Layout || IsMLA, "DSv4 page-padded layout is K-only (MLA).");
-  // todo hisparse: support page wise sparsity
   constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
   constexpr int NUM_TOKEN_CHUNKS = (NUM_TOP_K + WARP_SIZE - 1) / WARP_SIZE;
   constexpr int NUM_BUFFER_CHUNKS = (HOT_BUFFER_SIZE + WARP_SIZE - 1) / WARP_SIZE;
 
   const int bid = blockIdx.x;
-  // Early exit for padded blocks (CUDA graph pads batch to a captured size)
   if (bid >= num_real_reqs[0]) return;
 
   const int tid = threadIdx.x;
@@ -135,268 +196,296 @@ __global__ void load_cache_to_device_buffer_kernel(
   const unsigned int lanes_before = ((unsigned int)1 << lane_id) - 1;
 
   const int64_t rid = req_pool_indices[bid];
-  const int64_t seq_len = seq_lens[bid];
 
-  // Calculate offsets for this request
-  const int32_t* req_top_k_tokens = top_k_tokens + bid * top_k_tokens_stride;
-  int32_t* req_top_k_device_locs = top_k_device_locs + bid * top_k_device_locs_stride;
-
+  // Per-request pointers (invariant across steps)
   const int64_t buffer_offset = rid * buffer_stride_0;
   int32_t* req_device_buffer_tokens = device_buffer_tokens + buffer_offset;
   const int32_t* req_device_buffer_locs = device_buffer_locs + buffer_offset;
   const int64_t* req_host_cache_locs = host_cache_locs + rid * host_stride;
   int16_t* req_lru_slots = lru_slots + rid * lru_slot_stride_0;
 
-  // Fast path: short sequences have all tokens in the device buffer in order.
-  if (seq_len <= HOT_BUFFER_SIZE) {
-    const int count = (seq_len < NUM_TOP_K) ? static_cast<int>(seq_len) : NUM_TOP_K;
-    for (int i = tid; i < count; i += BLOCK_SIZE) {
-      int32_t token_pos = req_top_k_tokens[i];
-      if (token_pos >= 0) {
-        req_top_k_device_locs[i] = req_device_buffer_locs[token_pos];
-      }
-    }
-    return;
-  }
+  // Base pointers for this request's top_k data (steps are contiguous after)
+  const int32_t* req_top_k_tokens_base = top_k_tokens + bid * top_k_tokens_stride;
+  int32_t* req_top_k_device_locs_base = top_k_device_locs + bid * top_k_device_locs_stride;
 
-  // Dynamic shared memory layout: int32_t arrays first, then int16_t arrays.
+  // Shared memory layout (allocated once, reused across steps)
   extern __shared__ char smem_raw[];
   using Layout = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>;
   constexpr int HASH_SIZE = Layout::HASH_SIZE;
 
   int32_t* smem_i32 = reinterpret_cast<int32_t*>(smem_raw);
-  // Top-k token positions; reused as miss-token scratch in the copy phase
   int32_t* s_top_k_tokens = smem_i32;
-  // Prefix-sum offsets for hit counting and miss counting
   int32_t* s_chunk_offset = s_top_k_tokens + NUM_TOP_K;
-  // Prefix-sum offsets for evictable counting
   int32_t* s_evict_chunk_offset = s_chunk_offset + (NUM_BUFFER_CHUNKS + 1);
-  // Open-addressing hash table: top-k token_id -> top-k index (keys)
   int32_t* s_hash_keys = s_evict_chunk_offset + (NUM_BUFFER_CHUNKS + 1);
-  // Scalar counters
   int32_t& s_total_hits = s_hash_keys[HASH_SIZE];
   int32_t& s_newest_hit = s_hash_keys[HASH_SIZE + 1];
+  int32_t& s_total_misses = s_hash_keys[HASH_SIZE + 2];
 
   int16_t* smem_i16 = reinterpret_cast<int16_t*>(smem_i32 + Layout::TOTAL_INT32);
-  // Compacted slot ordering: [hits fwd->  ...  <-evictables bwd]
   int16_t* s_lru_slots_out = smem_i16;
-  // Open-addressing hash table: top-k token_id -> top-k index (values)
   int16_t* s_hash_vals = s_lru_slots_out + HOT_BUFFER_SIZE;
 
-  // Initialize shared memory: counters, hash table, prefix-sum offsets.
-  if (tid == 0) {
-    s_total_hits = 0;
-    s_newest_hit = 0;
-  }
-  for (int i = tid; i < HASH_SIZE; i += BLOCK_SIZE) {
-    s_hash_keys[i] = HASH_EMPTY;
-  }
-  for (int i = tid; i < NUM_BUFFER_CHUNKS + 1; i += BLOCK_SIZE) {
-    s_chunk_offset[i] = 0;
-    s_evict_chunk_offset[i] = 0;
-  }
-  __syncthreads();
+  for (int64_t step = 0; step < num_steps; step++) {
+    // Per-step pointers: [num_reqs, num_steps, NUM_TOP_K] req-major layout
+    const int32_t* step_top_k_tokens = req_top_k_tokens_base + step * NUM_TOP_K;
+    int32_t* step_top_k_device_locs = req_top_k_device_locs_base + step * NUM_TOP_K;
+    // seq_lens: [num_reqs * num_steps] flat req-major; index = bid * num_steps + step
+    const int64_t seq_len = static_cast<int64_t>(seq_lens[bid * num_steps + step]);
 
-  const int newest_slot = HOT_BUFFER_SIZE;
-  const int32_t newest_token = seq_len - 1;
-
-  // Insert top-k tokens into shared-memory hash table.
-  for (int i = tid; i < NUM_TOP_K; i += BLOCK_SIZE) {
-    int32_t token_idx = req_top_k_tokens[i];
-    if (token_idx == newest_token) {
-      // If topk includes the latest token, bind its canonical occurrence to newest_slot (at HOT_BUFFER_SIZE) and mark
-      // it as a hit. newest_slot is at the first position of the extra page, excluded from LRU tracking.
-      s_top_k_tokens[i] = TOKEN_HIT;
-      req_top_k_device_locs[i] = req_device_buffer_locs[newest_slot];
-      s_newest_hit = 1;
-    } else {
-      int slot = hash_slot(token_idx, HASH_SIZE);
-      while (true) {
-        int32_t old = atomicCAS(&s_hash_keys[slot], HASH_EMPTY, token_idx);
-        if (old == HASH_EMPTY || old == token_idx) {
-          s_hash_vals[slot] = static_cast<int16_t>(i);
-          break;
+    // Fast path: short sequences have all tokens in the device buffer in order.
+    if (seq_len <= HOT_BUFFER_SIZE) {
+      const int count = (seq_len < NUM_TOP_K) ? static_cast<int>(seq_len) : NUM_TOP_K;
+      for (int i = tid; i < count; i += BLOCK_SIZE) {
+        int32_t token_pos = step_top_k_tokens[i];
+        int32_t loc = -1;
+        if (try_get_static_device_loc<HOT_BUFFER_SIZE, IsDsv4Layout>(
+                token_pos, req_device_buffer_locs, page_size, &loc) ||
+            try_get_extra_page_device_loc<HOT_BUFFER_SIZE, IsDsv4Layout>(
+                token_pos,
+                seq_len,
+                step,
+                num_steps,
+                req_device_buffer_tokens,
+                req_device_buffer_locs,
+                page_size,
+                &loc)) {
+          step_top_k_device_locs[i] = loc;
         }
-        slot = (slot + 1) % HASH_SIZE;
       }
-      s_top_k_tokens[i] = token_idx;
-    }
-  }
-  __syncthreads();
-
-  constexpr int ITERATIONS_PER_WARP_BUFFER = (NUM_BUFFER_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
-  int total_hit_count = 0;
-  int total_evict_count = 0;
-  for (int iter = 0; iter < ITERATIONS_PER_WARP_BUFFER; iter++) {
-    int chunk_idx = warp_id + iter * NUM_WARPS;
-    bool has_valid_chunk = chunk_idx < NUM_BUFFER_CHUNKS;
-
-    const int slot_idx = chunk_idx * WARP_SIZE + lane_id;
-    const bool has_valid_slot = has_valid_chunk && (slot_idx < HOT_BUFFER_SIZE);
-    const int16_t buf_slot = has_valid_slot ? req_lru_slots[slot_idx] : -1;
-    int32_t my_buffer_token = (buf_slot >= 0) ? req_device_buffer_tokens[buf_slot] : -1;
-    int my_found_top_k_idx = -1;
-    if (my_buffer_token >= 0) {
-      int h = hash_slot(my_buffer_token, HASH_SIZE);
-      while (true) {
-        int32_t k = s_hash_keys[h];
-        if (k == my_buffer_token) {
-          my_found_top_k_idx = static_cast<int32_t>(s_hash_vals[h]);
-          break;
-        }
-        if (k == HASH_EMPTY) break;
-        h = (h + 1) % HASH_SIZE;
-      }
-    }
-    bool is_hit = my_found_top_k_idx >= 0;
-    bool is_evictable = has_valid_slot && !is_hit;
-
-    // Record hits
-    if (is_hit) {
-      s_top_k_tokens[my_found_top_k_idx] = TOKEN_HIT;
-      req_top_k_device_locs[my_found_top_k_idx] = req_device_buffer_locs[buf_slot];
+      continue;
     }
 
-    int local_hit_offset = 0;
-    int local_evict_offset = 0;
-    if (has_valid_chunk) {
-      const unsigned int hit_mask = __ballot_sync(0xFFFFFFFF, is_hit);
-      const unsigned int evict_mask = __ballot_sync(0xFFFFFFFF, is_evictable);
-      local_hit_offset = __popc(hit_mask & lanes_before);
-      local_evict_offset = __popc(evict_mask & lanes_before);
-      if (lane_id == 0) {
-        s_chunk_offset[chunk_idx + 1] = __popc(hit_mask);
-        s_evict_chunk_offset[chunk_idx + 1] = __popc(evict_mask);
-      }
+    // Initialize shared memory for this step
+    if (tid == 0) {
+      s_total_hits = 0;
+      s_newest_hit = 0;
+      s_total_misses = 0;
+    }
+    for (int i = tid; i < HASH_SIZE; i += BLOCK_SIZE) {
+      s_hash_keys[i] = HASH_EMPTY;
+    }
+    for (int i = tid; i < NUM_BUFFER_CHUNKS + 1; i += BLOCK_SIZE) {
+      s_chunk_offset[i] = 0;
+      s_evict_chunk_offset[i] = 0;
     }
     __syncthreads();
 
-    if (warp_id == 0) {
-      total_hit_count =
-          warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_hit_count);
-      total_evict_count =
-          warp_inclusive_scan(s_evict_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_evict_count);
-      if (tid == 0) {
-        s_total_hits = total_hit_count;
-      }
-    }
-    __syncthreads();
-
-    // Hits grow forward from index 0
-    if (is_hit) {
-      int hit_offset = s_chunk_offset[chunk_idx] + local_hit_offset;
-      s_lru_slots_out[hit_offset] = buf_slot;
-    }
-    // Evictables grow backward from HOT_BUFFER_SIZE - 1
-    if (is_evictable) {
-      int evict_offset = s_evict_chunk_offset[chunk_idx] + local_evict_offset;
-      s_lru_slots_out[HOT_BUFFER_SIZE - 1 - evict_offset] = buf_slot;
-    }
-  }
-  __syncthreads();
-
-  // Reset offsets for the miss counting phase (only NUM_TOKEN_CHUNKS + 1 entries needed).
-  for (int i = tid; i < NUM_TOKEN_CHUNKS + 1; i += BLOCK_SIZE) {
-    s_chunk_offset[i] = 0;
-  }
-  __syncthreads();
-
-  // Third pass to identify misses and their evictable slots
-  int total_misses = 0;
-  constexpr int ITERATIONS_PER_WARP_TOKEN = (NUM_TOKEN_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
-  for (int iter = 0; iter < ITERATIONS_PER_WARP_TOKEN; iter++) {
-    int chunk_idx = warp_id + iter * NUM_WARPS;
-    bool has_valid_chunk = chunk_idx < NUM_TOKEN_CHUNKS;
-
-    const int chunk_token_start = chunk_idx * WARP_SIZE;
-    const int my_token_idx = chunk_token_start + lane_id;
-    const bool has_valid_token = has_valid_chunk && (my_token_idx < NUM_TOP_K);
-
-    int32_t my_token = 0;
-    bool is_miss = false;
-    int local_miss_offset = 0;
-
-    if (has_valid_token) {
-      is_miss = s_top_k_tokens[my_token_idx] != TOKEN_HIT;
-      if (is_miss) {
-        my_token = s_top_k_tokens[my_token_idx];
-      }
-    }
-
-    if (has_valid_chunk) {
-      const unsigned int miss_mask = __ballot_sync(0xFFFFFFFF, is_miss);
-      local_miss_offset = __popc(miss_mask & lanes_before);
-      const int warp_miss_count = __popc(miss_mask);
-      if (lane_id == 0) {
-        s_chunk_offset[chunk_idx + 1] = warp_miss_count;
-      }
-    }
-    __syncthreads();
-
-    if (warp_id == 0) {
-      total_misses = warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_TOKEN_CHUNKS + 1, total_misses);
-    }
-    __syncthreads();
-
-    if (is_miss) {
-      int miss_offset = s_chunk_offset[chunk_idx] + local_miss_offset;
-      int16_t evict_slot = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_offset];
-      // Reuse s_top_k_tokens as miss scratch: miss_offset < my_token_idx always
-      // holds (hits are skipped), so compacted writes never overrun pending reads.
-      s_top_k_tokens[miss_offset] = my_token;
-      req_top_k_device_locs[my_token_idx] = req_device_buffer_locs[evict_slot];
-      req_device_buffer_tokens[evict_slot] = my_token;
-    }
-  }
-  __syncthreads();
-
-  total_misses = NUM_TOP_K - s_total_hits - s_newest_hit;
-  // Write back LRU order: evictables at front (LRU), hits at back (MRU).
-  {
-    const int total_evictable = HOT_BUFFER_SIZE - s_total_hits;
-    for (int i = tid; i < HOT_BUFFER_SIZE; i += BLOCK_SIZE) {
-      if (i < total_misses) {
-        // Misses: just loaded from host, place right before hits
-        req_lru_slots[total_evictable - total_misses + i] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
-      } else if (i < total_evictable) {
-        // Remaining evictables: truly stale, dest at LRU front
-        req_lru_slots[i - total_misses] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+    // Insert top-k tokens into shared-memory hash table.
+    for (int i = tid; i < NUM_TOP_K; i += BLOCK_SIZE) {
+      int32_t token_idx = step_top_k_tokens[i];
+      if (token_idx < 0 || token_idx >= seq_len) {
+        s_top_k_tokens[i] = TOKEN_HIT;
+        step_top_k_device_locs[i] = -1;
       } else {
-        // Hits: source at forward end, dest at MRU back
-        req_lru_slots[i] = s_lru_slots_out[i - total_evictable];
+        int32_t direct_loc = -1;
+        if (try_get_extra_page_device_loc<HOT_BUFFER_SIZE, IsDsv4Layout>(
+                token_idx,
+                seq_len,
+                step,
+                num_steps,
+                req_device_buffer_tokens,
+                req_device_buffer_locs,
+                page_size,
+                &direct_loc)) {
+          s_top_k_tokens[i] = TOKEN_HIT;
+          step_top_k_device_locs[i] = direct_loc;
+          continue;
+        }
+
+        int slot = hash_slot(token_idx, HASH_SIZE);
+        while (true) {
+          int32_t old = atomicCAS(&s_hash_keys[slot], HASH_EMPTY, token_idx);
+          if (old == HASH_EMPTY || old == token_idx) {
+            s_hash_vals[slot] = static_cast<int16_t>(i);
+            break;
+          }
+          slot = (slot + 1) % HASH_SIZE;
+        }
+        s_top_k_tokens[i] = token_idx;
       }
     }
-  }
+    __syncthreads();
 
-  // each warp copies one miss directly, can be separated into a new kernel if parallelism is a concern
-  for (int miss_idx = warp_id; miss_idx < total_misses; miss_idx += NUM_WARPS) {
-    const int32_t miss_token = s_top_k_tokens[miss_idx];
-    const int16_t evict_slot = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_idx];
+    // Scan device buffer slots in LRU order, marking hits and evictables.
+    constexpr int ITERATIONS_PER_WARP_BUFFER = (NUM_BUFFER_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
+    int total_hit_count = 0;
+    int total_evict_count = 0;
+    for (int iter = 0; iter < ITERATIONS_PER_WARP_BUFFER; iter++) {
+      int chunk_idx = warp_id + iter * NUM_WARPS;
+      bool has_valid_chunk = chunk_idx < NUM_BUFFER_CHUNKS;
 
-    const int64_t src_loc = req_host_cache_locs[miss_token];
-    const int64_t dst_loc = static_cast<int64_t>(req_device_buffer_locs[evict_slot]);
+      const int slot_idx = chunk_idx * WARP_SIZE + lane_id;
+      const bool has_valid_slot = has_valid_chunk && (slot_idx < HOT_BUFFER_SIZE);
+      const int16_t buf_slot = has_valid_slot ? req_lru_slots[slot_idx] : -1;
+      int32_t my_buffer_token = (buf_slot >= 0) ? req_device_buffer_tokens[buf_slot] : -1;
+      int my_found_top_k_idx = -1;
+      if (my_buffer_token >= 0) {
+        int h = hash_slot(my_buffer_token, HASH_SIZE);
+        while (true) {
+          int32_t k = s_hash_keys[h];
+          if (k == my_buffer_token) {
+            my_found_top_k_idx = static_cast<int32_t>(s_hash_vals[h]);
+            break;
+          }
+          if (k == HASH_EMPTY) break;
+          h = (h + 1) % HASH_SIZE;
+        }
+      }
+      bool is_hit = my_found_top_k_idx >= 0;
+      bool is_evictable = has_valid_slot && !is_hit;
 
-    if constexpr (IsDsv4Layout) {
-      // DSv4 path: page-padded device layout + linear host layout, K-only.
-      // Uses kvcacheio.cuh's hardcoded constants (kGPUPageSize=64, kCPUItemBytes=584).
-      device::hisparse::transfer_item<device::hisparse::TransferDirection::HostToDevice>(
-          /*dst_cache=*/device_buffer_k,
-          /*src_cache=*/const_cast<void*>(host_cache_k),
-          /*dst_index=*/static_cast<int32_t>(dst_loc),
-          /*src_index=*/static_cast<int32_t>(src_loc));
-    } else {
-      // Generic path: device + host both linear, stride = item_size_bytes.
-      const auto src_k = static_cast<const char*>(host_cache_k) + src_loc * item_size_bytes;
-      auto dst_k = static_cast<char*>(device_buffer_k) + dst_loc * item_size_bytes;
-      transfer_item_warp(lane_id, src_k, dst_k, item_size_bytes);
+      if (is_hit) {
+        s_top_k_tokens[my_found_top_k_idx] = TOKEN_HIT;
+        step_top_k_device_locs[my_found_top_k_idx] = req_device_buffer_locs[buf_slot];
+      }
 
-      if constexpr (!IsMLA) {
-        const auto src_v = static_cast<const char*>(host_cache_v) + src_loc * item_size_bytes;
-        auto dst_v = static_cast<char*>(device_buffer_v) + dst_loc * item_size_bytes;
-        transfer_item_warp(lane_id, src_v, dst_v, item_size_bytes);
+      int local_hit_offset = 0;
+      int local_evict_offset = 0;
+      if (has_valid_chunk) {
+        const unsigned int hit_mask = __ballot_sync(0xFFFFFFFF, is_hit);
+        const unsigned int evict_mask = __ballot_sync(0xFFFFFFFF, is_evictable);
+        local_hit_offset = __popc(hit_mask & lanes_before);
+        local_evict_offset = __popc(evict_mask & lanes_before);
+        if (lane_id == 0) {
+          s_chunk_offset[chunk_idx + 1] = __popc(hit_mask);
+          s_evict_chunk_offset[chunk_idx + 1] = __popc(evict_mask);
+        }
+      }
+      __syncthreads();
+
+      if (warp_id == 0) {
+        total_hit_count =
+            warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_hit_count);
+        total_evict_count =
+            warp_inclusive_scan(s_evict_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_evict_count);
+        if (tid == 0) {
+          s_total_hits = total_hit_count;
+        }
+      }
+      __syncthreads();
+
+      if (is_hit) {
+        int hit_offset = s_chunk_offset[chunk_idx] + local_hit_offset;
+        s_lru_slots_out[hit_offset] = buf_slot;
+      }
+      if (is_evictable) {
+        int evict_offset = s_evict_chunk_offset[chunk_idx] + local_evict_offset;
+        s_lru_slots_out[HOT_BUFFER_SIZE - 1 - evict_offset] = buf_slot;
       }
     }
-  }
+    __syncthreads();
+
+    // Reset offsets for the miss counting phase.
+    for (int i = tid; i < NUM_TOKEN_CHUNKS + 1; i += BLOCK_SIZE) {
+      s_chunk_offset[i] = 0;
+    }
+    __syncthreads();
+
+    // Identify misses and assign evict slots.
+    int total_misses = 0;
+    constexpr int ITERATIONS_PER_WARP_TOKEN = (NUM_TOKEN_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
+    for (int iter = 0; iter < ITERATIONS_PER_WARP_TOKEN; iter++) {
+      int chunk_idx = warp_id + iter * NUM_WARPS;
+      bool has_valid_chunk = chunk_idx < NUM_TOKEN_CHUNKS;
+
+      const int chunk_token_start = chunk_idx * WARP_SIZE;
+      const int my_token_idx = chunk_token_start + lane_id;
+      const bool has_valid_token = has_valid_chunk && (my_token_idx < NUM_TOP_K);
+
+      int32_t my_token = 0;
+      bool is_miss = false;
+      int local_miss_offset = 0;
+
+      if (has_valid_token) {
+        is_miss = s_top_k_tokens[my_token_idx] != TOKEN_HIT;
+        if (is_miss) {
+          my_token = s_top_k_tokens[my_token_idx];
+          if (req_host_cache_locs[my_token] < 0) {
+            is_miss = false;
+            s_top_k_tokens[my_token_idx] = TOKEN_HIT;
+            step_top_k_device_locs[my_token_idx] = -1;
+          }
+        }
+      }
+
+      if (has_valid_chunk) {
+        const unsigned int miss_mask = __ballot_sync(0xFFFFFFFF, is_miss);
+        local_miss_offset = __popc(miss_mask & lanes_before);
+        const int warp_miss_count = __popc(miss_mask);
+        if (lane_id == 0) {
+          s_chunk_offset[chunk_idx + 1] = warp_miss_count;
+        }
+      }
+      __syncthreads();
+
+      if (warp_id == 0) {
+        total_misses = warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_TOKEN_CHUNKS + 1, total_misses);
+        if (tid == 0) {
+          s_total_misses = total_misses;
+        }
+      }
+      __syncthreads();
+
+      if (is_miss) {
+        int miss_offset = s_chunk_offset[chunk_idx] + local_miss_offset;
+        int16_t evict_slot = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_offset];
+        s_top_k_tokens[miss_offset] = my_token;
+        step_top_k_device_locs[my_token_idx] = req_device_buffer_locs[evict_slot];
+        req_device_buffer_tokens[evict_slot] = my_token;
+      }
+    }
+    __syncthreads();
+
+    total_misses = s_total_misses;
+
+    // Write back LRU order: evictables at front (LRU), hits at back (MRU).
+    {
+      const int total_evictable = HOT_BUFFER_SIZE - s_total_hits;
+      for (int i = tid; i < HOT_BUFFER_SIZE; i += BLOCK_SIZE) {
+        if (i < total_misses) {
+          req_lru_slots[total_evictable - total_misses + i] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+        } else if (i < total_evictable) {
+          req_lru_slots[i - total_misses] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+        } else {
+          req_lru_slots[i] = s_lru_slots_out[i - total_evictable];
+        }
+      }
+    }
+
+    // Copy missed pages from host to device buffer.
+    for (int miss_idx = warp_id; miss_idx < total_misses; miss_idx += NUM_WARPS) {
+      const int32_t miss_token = s_top_k_tokens[miss_idx];
+      const int16_t evict_slot = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_idx];
+
+      const int64_t src_loc = req_host_cache_locs[miss_token];
+      const int64_t dst_loc = static_cast<int64_t>(req_device_buffer_locs[evict_slot]);
+
+      if constexpr (IsDsv4Layout) {
+        device::hisparse::transfer_item<device::hisparse::TransferDirection::HostToDevice>(
+            /*dst_cache=*/device_buffer_k,
+            /*src_cache=*/const_cast<void*>(host_cache_k),
+            /*dst_index=*/static_cast<int32_t>(dst_loc),
+            /*src_index=*/static_cast<int32_t>(src_loc));
+      } else {
+        const auto src_k = static_cast<const char*>(host_cache_k) + src_loc * item_size_bytes;
+        auto dst_k = static_cast<char*>(device_buffer_k) + dst_loc * item_size_bytes;
+        transfer_item_warp(lane_id, src_k, dst_k, item_size_bytes);
+
+        if constexpr (!IsMLA) {
+          const auto src_v = static_cast<const char*>(host_cache_v) + src_loc * item_size_bytes;
+          auto dst_v = static_cast<char*>(device_buffer_v) + dst_loc * item_size_bytes;
+          transfer_item_warp(lane_id, src_v, dst_v, item_size_bytes);
+        }
+      }
+    }
+
+    // Ensure global writes (device_buffer_tokens, lru_slots) are visible to next step.
+    if (num_steps > 1) {
+      __threadfence_block();
+      __syncthreads();
+    }
+  }  // end step loop
 }
 
 template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, bool IsMLA, bool IsDsv4Layout>
@@ -415,7 +504,8 @@ void load_cache_to_device_buffer(
     tvm::ffi::TensorView lru_slots,
     tvm::ffi::TensorView num_real_reqs,
     int64_t page_size,
-    int64_t item_size_bytes) {
+    int64_t item_size_bytes,
+    int64_t num_steps) {
   using namespace host;
 
   const int64_t bs = top_k_tokens.shape()[0];
@@ -426,8 +516,6 @@ void load_cache_to_device_buffer(
   const int64_t top_k_device_locs_stride = top_k_device_locs.strides()[0];
   const auto device = LaunchKernel::resolve_device(top_k_tokens.device());
 
-  // Generic lambda: int32/int64 kernel variants are compiled for both
-  // seq_lens and req_pool_indices; the correct combo is selected at runtime.
   auto launch = [&](auto kernel_fn, const auto* seq_lens_ptr, const auto* req_pool_indices_ptr) {
     constexpr size_t smem_bytes = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>::BYTES;
     if constexpr (smem_bytes > 48u * 1024u) {
@@ -454,7 +542,8 @@ void load_cache_to_device_buffer(
         top_k_tokens_stride,
         top_k_device_locs_stride,
         page_size,
-        item_size_bytes);
+        item_size_bytes,
+        num_steps);
   };
 
   const auto seq_dtype = seq_lens.dtype();

--- a/python/sglang/jit_kernel/hisparse.py
+++ b/python/sglang/jit_kernel/hisparse.py
@@ -10,6 +10,8 @@ from sglang.jit_kernel.utils import load_jit, make_cpp_args
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
+_HISPARSE_JIT_CACHE_VERSION = 6
+
 
 @functools.cache
 def _jit_sparse_module(
@@ -24,7 +26,13 @@ def _jit_sparse_module(
         block_size, num_top_k, hot_buffer_size, is_mla, is_dsv4_layout
     )
     cache_args = make_cpp_args(
-        item_size_bytes, block_size, num_top_k, hot_buffer_size, is_mla, is_dsv4_layout
+        _HISPARSE_JIT_CACHE_VERSION,
+        item_size_bytes,
+        block_size,
+        num_top_k,
+        hot_buffer_size,
+        is_mla,
+        is_dsv4_layout,
     )
     return load_jit(
         "sparse_cache",
@@ -58,6 +66,7 @@ def _load_cache_to_device_buffer_mla(
     page_size: int,
     block_size: int,
     num_real_reqs: torch.Tensor | None,
+    num_steps: int = 1,
 ) -> None:
     assert (
         hot_buffer_size >= num_top_k
@@ -95,6 +104,7 @@ def _load_cache_to_device_buffer_mla(
         num_real_reqs,
         page_size,
         item_size_bytes,
+        num_steps,
     )
 
 
@@ -115,6 +125,7 @@ def load_cache_to_device_buffer_mla(
     page_size: int = 1,
     block_size: int = 256,
     num_real_reqs: torch.Tensor | None = None,
+    num_steps: int = 1,
 ) -> None:
     """Generic MLA hisparse swap-in: device + host both linear (stride=item_size_bytes)."""
     _load_cache_to_device_buffer_mla(
@@ -135,6 +146,7 @@ def load_cache_to_device_buffer_mla(
         page_size=page_size,
         block_size=block_size,
         num_real_reqs=num_real_reqs,
+        num_steps=num_steps,
     )
 
 
@@ -155,6 +167,7 @@ def load_cache_to_device_buffer_dsv4_mla(
     page_size: int = 1,
     block_size: int = 256,
     num_real_reqs: torch.Tensor | None = None,
+    num_steps: int = 1,
 ) -> None:
     """DSv4 hisparse swap-in: page-padded device + linear host (kvcacheio.cuh layout)."""
     _load_cache_to_device_buffer_mla(
@@ -175,4 +188,5 @@ def load_cache_to_device_buffer_dsv4_mla(
         page_size=page_size,
         block_size=block_size,
         num_real_reqs=num_real_reqs,
+        num_steps=num_steps,
     )

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -32,6 +32,7 @@ class KVArgs:
     kv_data_ptrs: List[int]
     kv_data_lens: List[int]
     kv_item_lens: List[int]
+    target_kv_data_ptr_count: int
     aux_data_ptrs: List[int]
     aux_data_lens: List[int]
     aux_item_lens: List[int]

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -132,6 +132,7 @@ class CommonKVManager(BaseKVManager):
         logger.debug(f"kv manager bind to {self.local_ip}:{self.rank_port}")
 
         self.request_status: Dict[int, KVPoll] = {}
+        self.status_lock = threading.RLock()
         self.failure_records: Dict[int, str] = {}
         self.failure_lock = threading.Lock()
 
@@ -188,24 +189,33 @@ class CommonKVManager(BaseKVManager):
             )
 
     def check_status(self, bootstrap_room: int) -> KVPoll:
-        return self.request_status[bootstrap_room]
+        with self.status_lock:
+            return self.request_status[bootstrap_room]
 
     def update_status(self, bootstrap_room: int, status: KVPoll):
-        if bootstrap_room not in self.request_status:
-            # Do not resurrect a cleared entry with Failed: once clear() has
-            # popped the room from request_status, any late update_status(Failed)
-            # (e.g. from abort()) must be a no-op. Otherwise a Failed entry could
-            # pollute a future request that reuses the same bootstrap_room.
-            if status == KVPoll.Failed:
-                return
-            self.request_status[bootstrap_room] = status
-        else:
-            if status == KVPoll.Failed:
-                self.request_status[bootstrap_room] = KVPoll.Failed
+        with self.status_lock:
+            if bootstrap_room not in self.request_status:
+                # Do not resurrect a cleared entry with Failed: once clear() has
+                # popped the room from request_status, any late update_status(Failed)
+                # (e.g. from abort()) must be a no-op. Otherwise a Failed entry could
+                # pollute a future request that reuses the same bootstrap_room.
+                if status == KVPoll.Failed:
+                    return
+                self.request_status[bootstrap_room] = status
             else:
-                self.request_status[bootstrap_room] = max(
-                    self.request_status[bootstrap_room], status
-                )
+                if status == KVPoll.Failed:
+                    self.request_status[bootstrap_room] = KVPoll.Failed
+                else:
+                    self.request_status[bootstrap_room] = max(
+                        self.request_status[bootstrap_room], status
+                    )
+
+    def update_status_if_present(self, bootstrap_room: int, status: KVPoll) -> bool:
+        with self.status_lock:
+            if bootstrap_room not in self.request_status:
+                return False
+            self.update_status(bootstrap_room, status)
+            return True
 
     def record_failure(self, bootstrap_room: int, failure_reason: str):
         with self.failure_lock:
@@ -713,11 +723,12 @@ class CommonKVSender(BaseKVSender):
         raise Exception("Fake KVReceiver Exception")
 
     def clear(self) -> None:
-        self.kv_mgr.request_status.pop(self.bootstrap_room, None)
-        if hasattr(self.kv_mgr, "req_to_decode_prefix_len"):
-            self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, None)
-        if hasattr(self.kv_mgr, "transfer_infos"):
-            self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
+        with self.kv_mgr.status_lock:
+            self.kv_mgr.request_status.pop(self.bootstrap_room, None)
+            if hasattr(self.kv_mgr, "req_to_decode_prefix_len"):
+                self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, None)
+            if hasattr(self.kv_mgr, "transfer_infos"):
+                self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
 
     def abort(self):
         self.kv_mgr.record_failure(
@@ -918,9 +929,12 @@ class CommonKVReceiver(BaseKVReceiver):
         raise Exception("Fake KVReceiver Exception")
 
     def clear(self) -> None:
-        self.kv_mgr.request_status.pop(self.bootstrap_room, None)
-        self.kv_mgr.required_prefill_response_num_table.pop(self.bootstrap_room, None)
-        self.kv_mgr.prefill_response_tracker.pop(self.bootstrap_room, None)
+        with self.kv_mgr.status_lock:
+            self.kv_mgr.request_status.pop(self.bootstrap_room, None)
+            self.kv_mgr.required_prefill_response_num_table.pop(
+                self.bootstrap_room, None
+            )
+            self.kv_mgr.prefill_response_tracker.pop(self.bootstrap_room, None)
 
     def abort(self):
         self.kv_mgr.record_failure(

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -160,6 +160,10 @@ class CommonKVManager(BaseKVManager):
             # fail to receive the KV indices from the decode instance of this request.
             # These timeout requests should be aborted to release the tree cache.
             self.bootstrap_timeout = envs.SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT.get()
+            # After KV transfer starts, prefill also needs a bounded wait for
+            # the final transfer status. Otherwise a dead decode session can
+            # leave requests in the prefill inflight queue forever.
+            self.waiting_timeout = envs.SGLANG_DISAGGREGATION_WAITING_TIMEOUT.get()
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
             self.enable_staging: bool = False
             self.connection_pool: Dict[str, Dict[str, Union[str, int]]] = {}

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -163,13 +163,13 @@ class DecodeReqToTokenPool:
         offset = 0
         for r in reqs:
             if r.req_pool_idx is None:
-                r.req_pool_idx = select_index[offset]
+                r.req_pool_idx = int(select_index[offset])
                 offset += 1
-        return [r.req_pool_idx for r in reqs]
+        return [int(r.req_pool_idx) for r in reqs]
 
     def free(self, req: "Req"):
         assert req.req_pool_idx is not None, "request must have req_pool_idx"
-        self.free_slots.append(req.req_pool_idx)
+        self.free_slots.append(int(req.req_pool_idx))
         req.req_pool_idx = None
 
     def clear(self):
@@ -590,16 +590,22 @@ class DecodePreallocQueue:
             if uses_swa_tail_prealloc and swa_required > swa_allocatable_tokens:
                 break
 
+            if self._pre_alloc(req) is None:
+                break
             resumed_reqs.append(req)
             indices_to_remove.add(i)
             req.is_retracted = False
-            self._pre_alloc(req)
             full_allocatable_tokens -= full_required
             if uses_swa_tail_prealloc:
                 swa_allocatable_tokens -= swa_required
 
-            # load from cpu, release the cpu copy
-            req.load_kv_cache(self.req_to_token_pool, self.token_to_kv_pool_allocator)
+            if self.scheduler.enable_hisparse:
+                self.scheduler.hisparse_coordinator.admit_request_direct(req)
+            else:
+                # load from cpu, release the cpu copy
+                req.load_kv_cache(
+                    self.req_to_token_pool, self.token_to_kv_pool_allocator
+                )
 
         self.retracted_queue = [
             entry
@@ -899,6 +905,10 @@ class DecodePreallocQueue:
                     break
 
             dst_kv_indices = self._pre_alloc(decode_req.req, prefix_indices, prefix_len)
+            if dst_kv_indices is None:
+                if prefix_len > 0:
+                    self.tree_cache.dec_lock_ref(decode_req.req.last_node)
+                break
             hisparse_req_budget -= 1
             # Recompute from actual pool state for the next queue entry.
             # This accounts for page rounding and newly locked evictable cache.
@@ -1203,7 +1213,7 @@ class DecodePreallocQueue:
         req: Req,
         prefix_indices: Optional[torch.Tensor] = None,
         prefix_len: Optional[int] = None,
-    ) -> torch.Tensor:
+    ) -> Optional[torch.Tensor]:
         """Pre-allocate the memory for req_to_token and token_kv_pool"""
         if prefix_len is None:
             prefix_len = 0
@@ -1269,15 +1279,26 @@ class DecodePreallocQueue:
                 last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
                 extend_num_tokens=fill_len,
             )
-            # Allocate host indices for the RDMA transfer target.
-            host_indices = coordinator.mem_pool_host.alloc(fill_len)
+            host_len = fill_len // coordinator.compress_ratio
+            host_indices = coordinator.pop_retracted_host_indices(req, host_len)
             if host_indices is None:
-                raise RuntimeError(
-                    f"HiSparse host mem pool alloc failed for {fill_len} tokens "
-                    f"in _pre_alloc (req {req.rid})"
-                )
-            host_indices = host_indices.to(device=coordinator.device)
-            coordinator.req_to_host_pool[req.req_pool_idx, :fill_len] = host_indices
+                # Allocate host indices for the RDMA transfer target.
+                host_indices = coordinator.mem_pool_host.alloc(host_len)
+                if host_indices is None:
+                    logger.warning(
+                        "HiSparse host prealloc skipped for req %s: need=%d, "
+                        "available=%d",
+                        req.rid,
+                        host_len,
+                        coordinator.mem_pool_host.available_size(),
+                    )
+                    self.token_to_kv_pool_allocator.logical_attn_allocator.free(kv_loc)
+                    self.req_to_token_pool.free(req)
+                    req.kv_allocated_len = 0
+                    req.kv_committed_len = 0
+                    return None
+                host_indices = host_indices.to(device=coordinator.device)
+            coordinator.req_to_host_pool[req.req_pool_idx, :host_len] = host_indices
         elif self.token_to_kv_pool_allocator.page_size == 1:
             kv_loc = self.token_to_kv_pool_allocator.alloc(delta_len)
         else:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -389,7 +389,13 @@ class DecodePreallocQueue:
             kv_data_ptrs, kv_data_lens, kv_item_lens = (
                 self.token_to_kv_pool.get_contiguous_buf_infos()
             )
-        if self.draft_token_to_kv_pool is not None:
+        kv_args.target_kv_data_ptr_count = len(kv_data_ptrs)
+        # HiSparse direct-to-host uses host-pool indices for target KV transfer.
+        # Draft KV remains device-indexed and cannot share that destination list.
+        if (
+            self.draft_token_to_kv_pool is not None
+            and not self.scheduler.enable_hisparse
+        ):
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -576,6 +576,11 @@ class DecodePreallocQueue:
             full_allocatable_tokens = self._allocatable_token_budgets(
                 count_retracted=False
             )
+        hisparse_host_allocatable_tokens = (
+            self._hisparse_host_allocatable_token_budget(count_retracted=False)
+            if self.scheduler.enable_hisparse
+            else int(1e18)
+        )
 
         for i, req in enumerate(self.retracted_queue):
             if rids_to_check is not None and req.rid not in rids_to_check:
@@ -589,6 +594,10 @@ class DecodePreallocQueue:
                 break
             if uses_swa_tail_prealloc and swa_required > swa_allocatable_tokens:
                 break
+            if self.scheduler.enable_hisparse:
+                host_required = self._hisparse_host_required_tokens(req)
+                if host_required > hisparse_host_allocatable_tokens:
+                    break
 
             if self._pre_alloc(req) is None:
                 break
@@ -598,6 +607,8 @@ class DecodePreallocQueue:
             full_allocatable_tokens -= full_required
             if uses_swa_tail_prealloc:
                 swa_allocatable_tokens -= swa_required
+            if self.scheduler.enable_hisparse:
+                hisparse_host_allocatable_tokens -= host_required
 
             if self.scheduler.enable_hisparse:
                 self.scheduler.hisparse_coordinator.admit_request_direct(req)
@@ -786,15 +797,20 @@ class DecodePreallocQueue:
             self.queue.sort(key=lambda r: r.req.priority * priority_sign)
 
         # First, remove all failed requests from the queue
+        aborted_rids = set()
         for i, decode_req in enumerate(self.queue):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
             if isinstance(decode_req.req.finished_reason, FINISH_ABORT):
+                decode_req.kv_receiver.abort()
+                if hasattr(decode_req.kv_receiver, "clear"):
+                    decode_req.kv_receiver.clear()
                 self.scheduler.stream_output(
                     [decode_req.req], decode_req.req.return_logprob
                 )
                 failed_reqs.append(decode_req)
                 indices_to_remove.add(i)
+                aborted_rids.add(decode_req.req.rid)
 
         # HiSparse physical constraint: max requests by device buffer capacity.
         # Each admitted req needs padded_buffer_size from hisparse device pool.
@@ -810,6 +826,11 @@ class DecodePreallocQueue:
                 hisparse_avail // self.scheduler.hisparse_coordinator.padded_buffer_size
                 - len(self.transfer_queue.queue),
             )
+            hisparse_host_allocatable_tokens = (
+                self._hisparse_host_allocatable_token_budget(count_retracted=True)
+            )
+        else:
+            hisparse_host_allocatable_tokens = int(1e18)
 
         # Then, preallocate the remaining requests if possible
         for i, decode_req in enumerate(self.queue):
@@ -904,6 +925,22 @@ class DecodePreallocQueue:
                         self.tree_cache.dec_lock_ref(decode_req.req.last_node)
                     break
 
+            if self.scheduler.enable_hisparse:
+                hisparse_host_required = self._hisparse_host_required_tokens(
+                    decode_req.req
+                )
+                if hisparse_host_required > hisparse_host_allocatable_tokens:
+                    logger.debug(
+                        "HiSparse host prealloc budget blocked req %s: need=%d, allocatable=%d, available=%d",
+                        decode_req.req.rid,
+                        hisparse_host_required,
+                        hisparse_host_allocatable_tokens,
+                        self.scheduler.hisparse_coordinator.mem_pool_host.available_size(),
+                    )
+                    if prefix_len > 0:
+                        self.tree_cache.dec_lock_ref(decode_req.req.last_node)
+                    break
+
             dst_kv_indices = self._pre_alloc(decode_req.req, prefix_indices, prefix_len)
             if dst_kv_indices is None:
                 if prefix_len > 0:
@@ -921,6 +958,8 @@ class DecodePreallocQueue:
                 # SWA budget uses simple decrement (no radix cache eviction in
                 # the SWA pool, so page-rounding drift is negligible).
                 swa_allocatable_tokens -= swa_required
+            if self.scheduler.enable_hisparse:
+                hisparse_host_allocatable_tokens -= hisparse_host_required
             decode_req.req.cache_protected_len = prefix_len
 
             if self.scheduler.enable_hisparse:
@@ -1018,6 +1057,12 @@ class DecodePreallocQueue:
         self.queue = [
             entry for i, entry in enumerate(self.queue) if i not in indices_to_remove
         ]
+        if aborted_rids:
+            self.pending_reqs = [
+                decode_req
+                for decode_req in self.pending_reqs
+                if decode_req.req.rid not in aborted_rids
+            ]
 
         return preallocated_reqs, failed_reqs
 
@@ -1059,6 +1104,89 @@ class DecodePreallocQueue:
         if n_active is None:
             n_active = self._active_req_count(extra_reserved_reqs)
         return self.num_reserved_decode_tokens * n_active
+
+    def _req_prealloc_full_len(self, req: Req) -> int:
+        return len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
+
+    def _req_committed_full_len(self, req: Req) -> int:
+        full_len = getattr(req, "kv_committed_len", None)
+        if full_len is None or full_len <= 0:
+            return self._req_prealloc_full_len(req)
+        return int(full_len)
+
+    def _req_remaining_decode_tokens(self, req: Req) -> int:
+        committed_output_len = max(
+            0, self._req_committed_full_len(req) - len(req.origin_input_ids)
+        )
+        max_new_tokens = min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKEN)
+        return max(0, max_new_tokens - committed_output_len)
+
+    def _hisparse_host_decode_reserve_len(
+        self, req: Req, num_decode_tokens: Optional[int] = None
+    ) -> int:
+        coordinator = self.scheduler.hisparse_coordinator
+        if num_decode_tokens is None:
+            num_decode_tokens = self.num_reserved_decode_tokens
+        return coordinator.host_decode_reserve_len(
+            self._req_committed_full_len(req), num_decode_tokens
+        )
+
+    def _hisparse_host_remaining_decode_reserve_len(self, req: Req) -> int:
+        return self._hisparse_host_decode_reserve_len(
+            req, self._req_remaining_decode_tokens(req)
+        )
+
+    def _hisparse_retracted_host_len(self, req: Req) -> int:
+        host_len = getattr(req, "hisparse_retracted_host_len", None)
+        if host_len is not None:
+            return int(host_len)
+        host_indices = getattr(req, "hisparse_retracted_host_indices", None)
+        return int(host_indices.numel()) if host_indices is not None else 0
+
+    def _hisparse_host_required_tokens(self, req: Req) -> int:
+        coordinator = self.scheduler.hisparse_coordinator
+        fill_len = self._req_prealloc_full_len(req)
+        host_len = coordinator.compressed_host_len(fill_len)
+        preserved_host_len = self._hisparse_retracted_host_len(req)
+        prompt_need = max(0, host_len - preserved_host_len)
+        return prompt_need + self._hisparse_host_remaining_decode_reserve_len(req)
+
+    def _hisparse_host_reserved_tokens(self, extra_reserved_reqs: int = 0) -> int:
+        coordinator = self.scheduler.hisparse_coordinator
+        reserved = 0
+
+        for req in self.scheduler.running_batch.reqs:
+            reserved += self._hisparse_host_remaining_decode_reserve_len(req)
+        for decode_req in self.transfer_queue.queue:
+            reserved += self._hisparse_host_remaining_decode_reserve_len(decode_req.req)
+        for req in self.scheduler.waiting_queue:
+            reserved += self._hisparse_host_remaining_decode_reserve_len(req)
+
+        last_batch = self.scheduler.last_batch
+        if last_batch and last_batch.forward_mode.is_prebuilt():
+            for req in last_batch.reqs:
+                reserved += self._hisparse_host_remaining_decode_reserve_len(req)
+
+        extra_reserve = coordinator.host_decode_reserve_len(
+            0, self.num_reserved_decode_tokens
+        )
+        return reserved + extra_reserve * extra_reserved_reqs
+
+    def _hisparse_host_allocatable_token_budget(
+        self, count_retracted: bool = True, extra_reserved_reqs: int = 0
+    ) -> int:
+        if not self.scheduler.enable_hisparse:
+            return int(1e18)
+
+        coordinator = self.scheduler.hisparse_coordinator
+        allocatable_tokens = (
+            coordinator.mem_pool_host.available_size()
+            - self._hisparse_host_reserved_tokens(extra_reserved_reqs)
+        )
+        if count_retracted:
+            for req in self.retracted_queue:
+                allocatable_tokens -= self._hisparse_host_required_tokens(req)
+        return allocatable_tokens
 
     def _swa_aware_allocatable_token_budgets(
         self,
@@ -1279,15 +1407,14 @@ class DecodePreallocQueue:
                 last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
                 extend_num_tokens=fill_len,
             )
-            host_len = fill_len // coordinator.compress_ratio
+            host_len = coordinator.compressed_host_len(fill_len)
             host_indices = coordinator.pop_retracted_host_indices(req, host_len)
             if host_indices is None:
                 # Allocate host indices for the RDMA transfer target.
                 host_indices = coordinator.mem_pool_host.alloc(host_len)
                 if host_indices is None:
                     logger.warning(
-                        "HiSparse host prealloc skipped for req %s: need=%d, "
-                        "available=%d",
+                        "HiSparse host prealloc skipped for req %s: need=%d, available=%d",
                         req.rid,
                         host_len,
                         coordinator.mem_pool_host.available_size(),

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -196,10 +196,10 @@ class MooncakeKVManager(CommonKVManager):
         self.register_buffer_to_engine()
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
-            self.start_prefill_thread()
             self.session_failures = defaultdict(int)
             self.failed_sessions = set()
             self.session_lock = threading.Lock()
+            self.start_prefill_thread()
             # Determine the number of threads to use for kv sender
             cpu_count = os.cpu_count()
             transfer_thread_pool_size = (
@@ -255,23 +255,31 @@ class MooncakeKVManager(CommonKVManager):
         self.engine = get_mooncake_transfer_engine()
 
     def register_buffer_to_engine(self):
+        def batch_register_or_raise(ptrs: list[int], lens: list[int], buffer_name: str):
+            ret = self.engine.batch_register(ptrs, lens)
+            if ret != 0:
+                raise RuntimeError(
+                    f"Mooncake failed to register {buffer_name} buffers "
+                    f"(count={len(ptrs)}, first_length={lens[0] if lens else 0})."
+                )
+
         # Batch register KV data buffers
         if self.kv_args.kv_data_ptrs and self.kv_args.kv_data_lens:
-            self.engine.batch_register(
-                self.kv_args.kv_data_ptrs, self.kv_args.kv_data_lens
+            batch_register_or_raise(
+                self.kv_args.kv_data_ptrs, self.kv_args.kv_data_lens, "KV data"
             )
 
         # Batch register auxiliary data buffers
         if self.kv_args.aux_data_ptrs and self.kv_args.aux_data_lens:
-            self.engine.batch_register(
-                self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens
+            batch_register_or_raise(
+                self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens, "auxiliary"
             )
 
-        for ptrs, lens in zip(
-            self.kv_args.state_data_ptrs, self.kv_args.state_data_lens
+        for index, (ptrs, lens) in enumerate(
+            zip(self.kv_args.state_data_ptrs, self.kv_args.state_data_lens)
         ):
             if ptrs and lens:
-                self.engine.batch_register(ptrs, lens)
+                batch_register_or_raise(ptrs, lens, f"state[{index}]")
 
     # ------------------------------------------------------------------
     # Staging buffer methods (all delegate to staging_handler.py)
@@ -719,7 +727,13 @@ class MooncakeKVManager(CommonKVManager):
         dst_kv_indices.  Expands both to token granularity before transfer.
         """
         page_size = self.kv_args.page_size
-        per_token_item_lens = [il // page_size for il in self.kv_args.kv_item_lens]
+        target_kv_ptr_count = getattr(
+            self.kv_args, "target_kv_data_ptr_count", len(self.kv_args.kv_data_ptrs)
+        )
+        src_data_ptrs = self.kv_args.kv_data_ptrs[:target_kv_ptr_count]
+        per_token_item_lens = [
+            il // page_size for il in self.kv_args.kv_item_lens[:target_kv_ptr_count]
+        ]
 
         # Expand page-level src indices to token-level
         base = np.repeat(prefill_kv_indices * page_size, page_size)
@@ -739,7 +753,7 @@ class MooncakeKVManager(CommonKVManager):
         )
         return self._send_kvcache_generic(
             mooncake_session_id=mooncake_session_id,
-            src_data_ptrs=self.kv_args.kv_data_ptrs,
+            src_data_ptrs=src_data_ptrs,
             dst_data_ptrs=dst_kv_ptrs,
             item_lens=per_token_item_lens,
             prefill_data_indices=expanded_src,
@@ -1218,12 +1232,33 @@ class MooncakeKVManager(CommonKVManager):
                 )
                 polls = []
                 dst_ranks_infos = []
+                status = self.request_status.get(kv_chunk.room)
+                if status == KVPoll.Failed:
+                    self.transfer_infos.pop(kv_chunk.room, None)
+                    self.req_to_decode_prefix_len.pop(kv_chunk.room, None)
+                    continue
+
                 # Unique id per prefill sender so decode's response set size matches expected_response_num.
                 prefill_unique_rank = (
                     self.attn_tp_rank * (self.pp_size * self.attn_cp_size)
                     + self.pp_rank * self.attn_cp_size
                     + self.attn_cp_rank
                 )
+                if status not in (
+                    None,
+                    KVPoll.Failed,
+                    KVPoll.Transferring,
+                    KVPoll.Success,
+                ):
+                    self.update_status(kv_chunk.room, KVPoll.Transferring)
+                    for req in reqs_to_be_processed:
+                        self.sync_status_to_decode_endpoint(
+                            req.endpoint,
+                            req.dst_port,
+                            req.room,
+                            KVPoll.Transferring,
+                            prefill_unique_rank,
+                        )
                 # When staging transfer is not yet ready (watermark/allocation pending),
                 # the chunk is re-enqueued and we break out of the req loop to retry later.
                 staging_deferred = False
@@ -1494,28 +1529,7 @@ class MooncakeKVManager(CommonKVManager):
                 bootstrap_room = int(bootstrap_room.decode("ascii"))
                 prefill_rank = int(prefill_rank.decode("ascii"))
 
-                if status == KVPoll.Success:
-                    if bootstrap_room in self.request_status:
-                        self.prefill_response_tracker[bootstrap_room].add(prefill_rank)
-                        expected_response_num = (
-                            self.required_prefill_response_num_table[bootstrap_room]
-                        )
-                        arrived_response_num = len(
-                            self.prefill_response_tracker[bootstrap_room]
-                        )
-                        if arrived_response_num == expected_response_num:
-                            if self.enable_staging:
-                                handler = self._staging_handler
-                                if handler.is_staging_room(bootstrap_room):
-                                    handler.submit_last_scatter_async(bootstrap_room)
-                                self._chunk_writer_counts.pop(bootstrap_room, None)
-                            self.update_status(bootstrap_room, KVPoll.Success)
-                elif status == KVPoll.Failed:
-                    self.record_failure(
-                        bootstrap_room,
-                        "Failed to get kvcache from prefill instance, it might be dead",
-                    )
-                    self.update_status(bootstrap_room, status)
+                self._handle_decode_status(bootstrap_room, status, prefill_rank)
 
         def heartbeat_checker():
             while True:
@@ -1573,6 +1587,47 @@ class MooncakeKVManager(CommonKVManager):
 
         threading.Thread(target=decode_thread).start()
         threading.Thread(target=heartbeat_checker).start()
+
+    def _handle_decode_status(
+        self, bootstrap_room: int, status: int, prefill_rank: int
+    ):
+        if status == KVPoll.Success:
+            with self.status_lock:
+                if bootstrap_room not in self.request_status:
+                    self.prefill_response_tracker.pop(bootstrap_room, None)
+                    return
+
+                expected_response_num = self.required_prefill_response_num_table.get(
+                    bootstrap_room
+                )
+                if expected_response_num is None:
+                    self.prefill_response_tracker.pop(bootstrap_room, None)
+                    return
+
+                self.prefill_response_tracker[bootstrap_room].add(prefill_rank)
+                arrived_response_num = len(
+                    self.prefill_response_tracker[bootstrap_room]
+                )
+                should_complete = arrived_response_num == expected_response_num
+
+            if should_complete:
+                if self.enable_staging:
+                    handler = self._staging_handler
+                    if handler.is_staging_room(bootstrap_room):
+                        handler.submit_last_scatter_async(bootstrap_room)
+                    self._chunk_writer_counts.pop(bootstrap_room, None)
+                self.update_status_if_present(bootstrap_room, KVPoll.Success)
+        elif status == KVPoll.Failed:
+            with self.status_lock:
+                if bootstrap_room not in self.request_status:
+                    return
+                self.record_failure(
+                    bootstrap_room,
+                    "Failed to get kvcache from prefill instance, it might be dead",
+                )
+                self.update_status(bootstrap_room, status)
+        elif status == KVPoll.Transferring:
+            self.update_status_if_present(bootstrap_room, status)
 
     def add_transfer_request(
         self,
@@ -1666,7 +1721,7 @@ class MooncakeKVSender(CommonKVSender):
     ):
         super().__init__(mgr, bootstrap_addr, bootstrap_room, dest_tp_ranks, pp_rank)
         self.conclude_state = None
-        self.init_time = time.time()
+        self.init_time = None
 
     def pop_decode_prefix_len(self) -> int:
         return self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, 0)
@@ -1721,6 +1776,13 @@ class MooncakeKVSender(CommonKVSender):
             if status in (KVPoll.Success, KVPoll.Failed):
                 self.conclude_state = status
             elif status == KVPoll.Bootstrapping:
+                # Queueing before decode admission is valid backpressure. Start
+                # the bootstrap timeout only after decode begins sending metadata.
+                if (
+                    self.init_time is None
+                    and self.bootstrap_room in self.kv_mgr.transfer_infos
+                ):
+                    self.init_time = time.time()
                 if self.init_time is not None:
                     now = time.time()
                     elapsed = now - self.init_time
@@ -1876,28 +1938,28 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         str(decode_prefix_len or 0).encode("ascii"),
                     ]
                 )
-        self.init_time = time.time()
 
     def poll(self) -> KVPoll:
         if self.conclude_state is None:
             status = self.kv_mgr.check_status(self.bootstrap_room)
             if status in (KVPoll.Success, KVPoll.Failed):
                 self.conclude_state = status
-            elif status == KVPoll.WaitingForInput:
-                if self.init_time is not None:
-                    now = time.time()
-                    elapsed = now - self.init_time
-                    if elapsed >= self.kv_mgr.waiting_timeout:
-                        logger.warning_once(
-                            "Some requests fail to receive KV Cache transfer done signal after bootstrapping. "
-                            "If a greater mean TTFT is acceptable, you can 'export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=600' (10 minutes) to relax the timeout condition. "
-                        )
-                        self.kv_mgr.record_failure(
-                            self.bootstrap_room,
-                            f"Request {self.bootstrap_room} timed out after {elapsed:.1f}s in KVPoll.WaitingForInput",
-                        )
-                        self.conclude_state = KVPoll.Failed
-                        return KVPoll.Failed
+            elif status == KVPoll.Transferring:
+                if self.init_time is None:
+                    self.init_time = time.time()
+                now = time.time()
+                elapsed = now - self.init_time
+                if elapsed >= self.kv_mgr.waiting_timeout:
+                    logger.warning_once(
+                        "Some requests fail to receive KV Cache transfer done signal after transferring starts. "
+                        "If a greater mean TTFT is acceptable, you can 'export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=600' (10 minutes) to relax the timeout condition. "
+                    )
+                    self.kv_mgr.record_failure(
+                        self.bootstrap_room,
+                        f"Request {self.bootstrap_room} timed out after {elapsed:.1f}s in KVPoll.Transferring",
+                    )
+                    self.conclude_state = KVPoll.Failed
+                    return KVPoll.Failed
 
             return status
 

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -141,8 +141,8 @@ class KVArgsRegisterInfo:
             endpoint=msg[1].decode("ascii"),
             dst_port=int(msg[2].decode("ascii")),
             mooncake_session_id=msg[3].decode("ascii"),
-            dst_kv_ptrs=list(struct.unpack(f"{len(msg[4])//8}Q", msg[4])),
-            dst_aux_ptrs=list(struct.unpack(f"{len(msg[5])//8}Q", msg[5])),
+            dst_kv_ptrs=list(struct.unpack(f"{len(msg[4]) // 8}Q", msg[4])),
+            dst_aux_ptrs=list(struct.unpack(f"{len(msg[5]) // 8}Q", msg[5])),
             dst_state_data_ptrs=unpack_int_lists(msg[6], "Q"),
             dst_tp_rank=int(msg[7].decode("ascii")),
             dst_attn_tp_size=int(msg[8].decode("ascii")),
@@ -183,6 +183,7 @@ class AuxDataCodec:
 
 class MooncakeKVManager(CommonKVManager):
     AUX_DATA_HEADER = b"AUX_DATA"
+    DECODE_STATUS_HEADER = b"STATUS"
 
     def __init__(
         self,
@@ -435,8 +436,7 @@ class MooncakeKVManager(CommonKVManager):
         )
         if ret == -1:
             logger.warning(
-                f"[Staging][tp{_tp}] Falling back to per-token slice path "
-                f"(room={kv_chunk.room})"
+                f"[Staging][tp{_tp}] Falling back to per-token slice path (room={kv_chunk.room})"
             )
             ret = self.send_kvcache_slice(
                 req.mooncake_session_id,
@@ -1437,6 +1437,9 @@ class MooncakeKVManager(CommonKVManager):
             while True:
                 waiting_req_bytes = self.server_socket.recv_multipart()
                 room = waiting_req_bytes[0].decode("ascii")
+                if room == MooncakeKVManager.DECODE_STATUS_HEADER.decode("ascii"):
+                    self._handle_prefill_decode_status(waiting_req_bytes)
+                    continue
                 # Staging: decode reports consumption watermark back to prefill
                 if room == "WATERMARK":
                     from sglang.srt.disaggregation.common.staging_handler import (
@@ -1489,6 +1492,27 @@ class MooncakeKVManager(CommonKVManager):
                         self.update_status(room, KVPoll.WaitingForInput)
 
         threading.Thread(target=bootstrap_thread).start()
+
+    def _handle_prefill_decode_status(self, msg):
+        room = int(msg[1].decode("ascii"))
+        status = int(msg[2].decode("ascii"))
+        reason = (
+            msg[3].decode("utf-8", errors="replace")
+            if len(msg) > 3
+            else "Decode instance failed before sending KV metadata"
+        )
+
+        if status != KVPoll.Failed:
+            return
+
+        with self.status_lock:
+            if room not in self.request_status:
+                return
+
+        self.record_failure(room, reason)
+        self.update_status(room, KVPoll.Failed)
+        self.transfer_infos.pop(room, None)
+        self.req_to_decode_prefix_len.pop(room, None)
 
     def start_decode_thread(self):
         def decode_thread():
@@ -1710,7 +1734,6 @@ class MooncakeKVManager(CommonKVManager):
 
 
 class MooncakeKVSender(CommonKVSender):
-
     def __init__(
         self,
         mgr: MooncakeKVManager,
@@ -1721,7 +1744,8 @@ class MooncakeKVSender(CommonKVSender):
     ):
         super().__init__(mgr, bootstrap_addr, bootstrap_room, dest_tp_ranks, pp_rank)
         self.conclude_state = None
-        self.init_time = None
+        self.init_time = time.time()
+        self.transfer_init_time = None
 
     def pop_decode_prefix_len(self) -> int:
         return self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, 0)
@@ -1776,12 +1800,7 @@ class MooncakeKVSender(CommonKVSender):
             if status in (KVPoll.Success, KVPoll.Failed):
                 self.conclude_state = status
             elif status == KVPoll.Bootstrapping:
-                # Queueing before decode admission is valid backpressure. Start
-                # the bootstrap timeout only after decode begins sending metadata.
-                if (
-                    self.init_time is None
-                    and self.bootstrap_room in self.kv_mgr.transfer_infos
-                ):
+                if self.init_time is None:
                     self.init_time = time.time()
                 if self.init_time is not None:
                     now = time.time()
@@ -1796,8 +1815,27 @@ class MooncakeKVSender(CommonKVSender):
                             self.bootstrap_room,
                             f"Request {self.bootstrap_room} timed out after {elapsed:.1f}s in KVPoll.Bootstrapping",
                         )
+                        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
                         self.conclude_state = KVPoll.Failed
                         return KVPoll.Failed
+            elif status == KVPoll.Transferring:
+                if self.transfer_init_time is None:
+                    self.transfer_init_time = time.time()
+                now = time.time()
+                elapsed = now - self.transfer_init_time
+                if elapsed >= self.kv_mgr.waiting_timeout:
+                    logger.warning_once(
+                        "Some requests timed out after prefill KV transfer started, "
+                        "which means prefill instances did not observe a terminal transfer status. "
+                        "If a greater mean TTFT is acceptable, you can 'export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=600' (10 minutes) to relax the timeout condition. "
+                    )
+                    self.kv_mgr.record_failure(
+                        self.bootstrap_room,
+                        f"Request {self.bootstrap_room} timed out after {elapsed:.1f}s in KVPoll.Transferring on prefill sender",
+                    )
+                    self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
+                    self.conclude_state = KVPoll.Failed
+                    return KVPoll.Failed
 
             return status
         else:
@@ -1938,6 +1976,47 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         str(decode_prefix_len or 0).encode("ascii"),
                     ]
                 )
+
+    def _notify_prefill_status(self, status: int, reason: str = "") -> bool:
+        bootstrap_infos = getattr(self, "bootstrap_infos", None)
+        if not bootstrap_infos:
+            return False
+
+        sent = False
+        for bootstrap_info in bootstrap_infos:
+            try:
+                sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
+                with lock:
+                    sock.send_multipart(
+                        [
+                            MooncakeKVManager.DECODE_STATUS_HEADER,
+                            str(self.bootstrap_room).encode("ascii"),
+                            str(status).encode("ascii"),
+                            reason.encode("utf-8"),
+                        ]
+                    )
+                sent = True
+            except Exception as e:
+                logger.warning(
+                    "Failed to notify prefill status for bootstrap_room=%s: %s",
+                    self.bootstrap_room,
+                    e,
+                )
+        return sent
+
+    def abort(self, reason: str = "Aborted by AbortReq."):
+        try:
+            status = self.kv_mgr.check_status(self.bootstrap_room)
+        except KeyError:
+            status = None
+
+        if status is not None:
+            self.kv_mgr.record_failure(self.bootstrap_room, reason)
+            if status == KVPoll.Bootstrapping:
+                self._notify_prefill_status(KVPoll.Failed, reason)
+            self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
+
+        self.conclude_state = KVPoll.Failed
 
     def poll(self) -> KVPoll:
         if self.conclude_state is None:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 from collections import deque
 from http import HTTPStatus
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Deque, List, Optional
 
 import torch
 
@@ -43,6 +43,7 @@ from sglang.srt.disaggregation.utils import (
     setup_state_kv_args,
 )
 from sglang.srt.environ import envs
+from sglang.srt.managers.io_struct import AbortReq
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
     FINISH_LENGTH,
@@ -122,6 +123,7 @@ class PrefillBootstrapQueue:
         self.gpu_id = gpu_id
         self.bootstrap_port = bootstrap_port
         self.queue: List[Req] = []
+        self.pending_queue: Deque[Req] = deque()
         self.gloo_group = gloo_group
         self.max_total_num_tokens = max_total_num_tokens
         self.scheduler = scheduler
@@ -152,6 +154,7 @@ class PrefillBootstrapQueue:
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()
         )
+        kv_args.target_kv_data_ptr_count = len(kv_data_ptrs)
 
         if self.draft_token_to_kv_pool is not None:
             # We should also transfer draft model kv cache. The indices are
@@ -219,10 +222,37 @@ class PrefillBootstrapQueue:
                 )
         return kv_manager
 
-    def add(self, req: Req, num_kv_heads: int) -> None:
-        if self._check_if_req_exceed_kv_capacity(req):
-            return
+    def _active_sender_req_count(self) -> int:
+        """Count requests that already own a prefill KV sender.
 
+        Requests without a sender have not entered Mooncake's bootstrapping
+        state yet, so they do not consume metadata buffers and cannot hit the
+        fixed bootstrap timeout.
+        """
+        active_rids = set()
+        queues = [
+            self.queue,
+            self.scheduler.waiting_queue,
+            getattr(self.scheduler, "disagg_prefill_inflight_queue", []),
+        ]
+        for batch_name in ("cur_batch", "last_batch", "running_batch"):
+            batch = getattr(self.scheduler, batch_name, None)
+            if batch is not None:
+                queues.append(getattr(batch, "reqs", []))
+
+        for reqs in queues:
+            for req in reqs:
+                if getattr(req, "disagg_kv_sender", None) is not None:
+                    active_rids.add(req.rid)
+        return len(active_rids)
+
+    def _max_active_sender_reqs(self) -> int:
+        return self.req_to_metadata_buffer_idx_allocator.size
+
+    def _can_admit_sender(self) -> bool:
+        return self._active_sender_req_count() < self._max_active_sender_reqs()
+
+    def _create_kv_sender(self, req: Req, num_kv_heads: int) -> None:
         backend = (
             TransferBackend.FAKE
             if req.bootstrap_host == FAKE_BOOTSTRAP_HOST
@@ -239,8 +269,23 @@ class PrefillBootstrapQueue:
             dest_tp_ranks=dest_tp_ranks,
             pp_rank=self.pp_rank,
         )
-        self._process_req(req)
         self.queue.append(req)
+
+    def _admit_pending(self, num_kv_heads: int) -> None:
+        while self.pending_queue and self._can_admit_sender():
+            req = self.pending_queue.popleft()
+            if isinstance(req.finished_reason, FINISH_ABORT):
+                self.scheduler.stream_output([req], req.return_logprob)
+                continue
+            self._create_kv_sender(req, num_kv_heads)
+
+    def add(self, req: Req, num_kv_heads: int) -> None:
+        if self._check_if_req_exceed_kv_capacity(req):
+            return
+
+        self._process_req(req)
+        self.pending_queue.append(req)
+        self._admit_pending(num_kv_heads)
 
     def extend(self, reqs: List[Req], num_kv_heads: int) -> None:
         for req in reqs:
@@ -277,6 +322,8 @@ class PrefillBootstrapQueue:
         bootstrapped_reqs = []
         failed_reqs = []
         indices_to_remove = set()
+
+        self._admit_pending(self.scheduler.model_config.num_key_value_heads)
 
         if len(self.queue) == 0:
             if return_failed_reqs is False:
@@ -514,6 +561,20 @@ class SchedulerDisaggregationPrefillMixin:
         for i, (req, next_token_id) in enumerate(
             zip(batch.reqs, next_token_ids, strict=True)
         ):
+            if isinstance(getattr(req, "to_finish", None), FINISH_ABORT) or isinstance(
+                req.finished_reason, FINISH_ABORT
+            ):
+                if hasattr(req.disagg_kv_sender, "abort"):
+                    req.disagg_kv_sender.abort()
+                if hasattr(req.disagg_kv_sender, "clear"):
+                    req.disagg_kv_sender.clear()
+                release_kv_cache(req, self.tree_cache, is_insert=False)
+                release_req_to_metadata_buffer(
+                    req, self.req_to_metadata_buffer_idx_allocator
+                )
+                self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+                continue
+
             if req.is_chunked <= 0:
                 req.time_stats.set_prefill_finished_time()
 

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -287,7 +287,9 @@ class NSAIndexerMetadata(BaseIndexerMetadata):
                 row_starts=ks,
             )
         else:
-            assert False, f"Unsupported {self.topk_transform_method = }"
+            assert (
+                False
+            ), f"Unsupported topk_transform_method={self.topk_transform_method}"
 
 
 _NSA_IMPL_T: TypeAlias = Literal[
@@ -1030,17 +1032,16 @@ class NativeSparseAttnBackend(
                 page_indices, repeats=self.speculative_num_draft_tokens, dim=0
             )
             metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
-            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * bs
-
-            seqlens_expanded = seqlens_expand_triton(
-                torch.tensor(
-                    extend_seq_lens_cpu, dtype=torch.int32, device=self.device
-                ),
-                cache_seqlens,
-                self.speculative_num_draft_tokens * bs,
-                self.speculative_num_draft_tokens,
+            # Compute seqlens_expanded in-place to avoid allocations that
+            # conflict with the CUDA graph memory pool.
+            # seqlens_expanded[i*draft_tokens+j] = cache_seqlens[i] - draft_tokens + 1 + j
+            draft_tokens = self.speculative_num_draft_tokens
+            total_len = draft_tokens * bs
+            metadata.nsa_seqlens_expanded[:total_len].view(bs, draft_tokens).copy_(
+                (cache_seqlens - draft_tokens + 1).unsqueeze(1)
+                + self.get_device_int32_arange(draft_tokens).unsqueeze(0)
             )
-            metadata.nsa_seqlens_expanded.copy_(seqlens_expanded)
+            seqlens_expanded = metadata.nsa_seqlens_expanded[:total_len]
             nsa_cache_seqlens = compute_nsa_seqlens(
                 seqlens_expanded, self.nsa_index_topk
             )
@@ -1450,13 +1451,37 @@ class NativeSparseAttnBackend(
                     page_size=1,
                 )
 
-        # todo hisparse: to cover more backends
         if forward_batch.hisparse_coordinator is not None:
-            page_table_1 = (
-                forward_batch.token_to_kv_pool.translate_loc_to_hisparse_device(
-                    page_table_1
+            if forward_batch.forward_mode.is_target_verify():
+                num_reqs = forward_batch.req_pool_indices.shape[0]
+                num_steps = self.speculative_num_draft_tokens
+                assert (
+                    topk_indices is not None
+                ), "topk_indices is None in TARGET_VERIFY/DRAFT_EXTEND_V2"
+                assert topk_indices.shape == (
+                    num_reqs * num_steps,
+                    self.nsa_index_topk,
+                ), (
+                    f"topk_indices shape mismatch: {topk_indices.shape} vs expected "
+                    f"({num_reqs * num_steps}, {self.nsa_index_topk}), "
+                    f"forward_mode={forward_batch.forward_mode}, num_reqs={num_reqs}, num_steps={num_steps}"
                 )
-            )
+                page_table_1 = (
+                    forward_batch.hisparse_coordinator.swap_in_selected_pages(
+                        forward_batch.req_pool_indices,
+                        metadata.nsa_seqlens_expanded,
+                        topk_indices.view(num_reqs, num_steps, -1),
+                        layer.layer_id,
+                        token_position_space="full",
+                        num_steps=num_steps,
+                    ).view(num_reqs * num_steps, -1)
+                )
+            else:
+                page_table_1 = (
+                    forward_batch.token_to_kv_pool.translate_loc_to_hisparse_device(
+                        page_table_1
+                    )
+                )
 
         if nsa_impl == "tilelang":
             if q_rope is not None:
@@ -1615,6 +1640,7 @@ class NativeSparseAttnBackend(
                 forward_batch.seq_lens,
                 topk_indices,
                 layer.layer_id,
+                token_position_space="full",
             )
         elif envs.SGLANG_NSA_FUSE_TOPK.get():
             page_table_1 = topk_indices
@@ -2271,9 +2297,9 @@ class NativeSparseAttnBackend(
     def get_indexer_metadata(
         self, layer_id: int, forward_batch: ForwardBatch
     ) -> NSAIndexerMetadata:
-        force_unfused = (
-            forward_batch.hisparse_coordinator is not None
-            and forward_batch.forward_mode.is_decode_or_idle()
+        force_unfused = forward_batch.hisparse_coordinator is not None and (
+            forward_batch.forward_mode.is_decode_or_idle()
+            or forward_batch.forward_mode.is_target_verify()
         )
         return NSAIndexerMetadata(
             attn_metadata=self.forward_metadata,

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -78,6 +78,13 @@ def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tens
     return seqlens_32.contiguous().view(-1, 1)
 
 
+def _uses_hisparse_device_mapping(forward_batch: ForwardBatch) -> bool:
+    translate_loc = getattr(
+        forward_batch.token_to_kv_pool, "translate_loc_to_hisparse_device", None
+    )
+    return callable(translate_loc)
+
+
 # Reuse this workspace buffer across all NSA backend instances
 global_workspace_buffer = None
 
@@ -1427,6 +1434,10 @@ class NativeSparseAttnBackend(
         topk_transform_method = self.get_topk_transform_method(
             forward_batch.forward_mode
         )
+        use_device_mapping_without_coordinator = (
+            forward_batch.hisparse_coordinator is None
+            and _uses_hisparse_device_mapping(forward_batch)
+        )
         if envs.SGLANG_NSA_FUSE_TOPK.get():
             page_table_1 = topk_indices
         else:
@@ -1476,12 +1487,28 @@ class NativeSparseAttnBackend(
                         num_steps=num_steps,
                     ).view(num_reqs * num_steps, -1)
                 )
+            elif forward_batch.forward_mode.is_draft_extend(include_v2=True):
+                assert (
+                    topk_indices is not None
+                ), "topk_indices is None in DRAFT_EXTEND/DRAFT_EXTEND_V2"
+                page_table_1 = self._swap_in_hisparse_draft_extend_pages(
+                    forward_batch,
+                    metadata,
+                    topk_indices,
+                    layer.layer_id,
+                )
             else:
                 page_table_1 = (
                     forward_batch.token_to_kv_pool.translate_loc_to_hisparse_device(
                         page_table_1
                     )
                 )
+        elif use_device_mapping_without_coordinator:
+            page_table_1 = (
+                forward_batch.token_to_kv_pool.translate_loc_to_hisparse_device(
+                    page_table_1
+                )
+            )
 
         if nsa_impl == "tilelang":
             if q_rope is not None:
@@ -1634,6 +1661,10 @@ class NativeSparseAttnBackend(
         if topk_indices is not None:
             topk_indices = self._pad_topk_indices(topk_indices, q_nope.shape[0])
 
+        use_device_mapping_without_coordinator = (
+            forward_batch.hisparse_coordinator is None
+            and _uses_hisparse_device_mapping(forward_batch)
+        )
         if forward_batch.hisparse_coordinator is not None:
             page_table_1 = forward_batch.hisparse_coordinator.swap_in_selected_pages(
                 forward_batch.req_pool_indices,
@@ -1649,6 +1680,13 @@ class NativeSparseAttnBackend(
                 page_table=metadata.page_table_1,
                 topk_indices=topk_indices,
                 page_size=1,
+            )
+
+        if use_device_mapping_without_coordinator:
+            page_table_1 = (
+                forward_batch.token_to_kv_pool.translate_loc_to_hisparse_device(
+                    page_table_1
+                )
             )
 
         if self.nsa_decode_impl == "flashmla_sparse":
@@ -2201,6 +2239,79 @@ class NativeSparseAttnBackend(
         # Output: [batch, q_len=1, heads, v_dim] -> [batch, heads, v_dim]
         return out.squeeze(1)
 
+    def _swap_in_hisparse_draft_extend_pages(
+        self,
+        forward_batch: ForwardBatch,
+        metadata: NSAMetadata,
+        topk_indices: torch.Tensor,
+        layer_id: int,
+    ) -> torch.Tensor:
+        """Swap HiSparse pages for variable-length DRAFT_EXTEND queries."""
+        assert forward_batch.hisparse_coordinator is not None
+
+        extend_lens_cpu = forward_batch.extend_seq_lens_cpu
+        if extend_lens_cpu is None:
+            extend_lens_cpu = metadata.nsa_extend_seq_lens_list
+        extend_lens_cpu = [int(x) for x in extend_lens_cpu]
+
+        num_reqs = forward_batch.req_pool_indices.shape[0]
+        extend_lens_cpu = extend_lens_cpu[:num_reqs]
+        total_extend = sum(extend_lens_cpu)
+        if total_extend == 0:
+            return topk_indices.new_full(topk_indices.shape, -1)
+
+        max_steps = max(extend_lens_cpu)
+        if max_steps == 0:
+            return topk_indices.new_full(topk_indices.shape, -1)
+
+        real_topk = topk_indices[:total_extend]
+        padded_topk = topk_indices.new_full(
+            (num_reqs, max_steps, topk_indices.shape[-1]), -1
+        )
+        padded_seq_lens = metadata.nsa_seqlens_expanded.new_ones((num_reqs, max_steps))
+
+        offset = 0
+        for req_idx, extend_len in enumerate(extend_lens_cpu):
+            if extend_len == 0:
+                continue
+            next_offset = offset + extend_len
+            padded_topk[req_idx, :extend_len].copy_(real_topk[offset:next_offset])
+            padded_seq_lens[req_idx, :extend_len].copy_(
+                metadata.nsa_seqlens_expanded[offset:next_offset]
+            )
+            offset = next_offset
+
+        swapped = forward_batch.hisparse_coordinator.swap_in_selected_pages(
+            forward_batch.req_pool_indices,
+            padded_seq_lens.reshape(-1),
+            padded_topk,
+            layer_id,
+            token_position_space="full",
+            num_steps=max_steps,
+        )
+
+        rows = [
+            swapped[req_idx, :extend_len]
+            for req_idx, extend_len in enumerate(extend_lens_cpu)
+            if extend_len > 0
+        ]
+        page_table_1 = torch.cat(rows, dim=0)
+        if topk_indices.shape[0] > total_extend:
+            page_table_1 = torch.cat(
+                [
+                    page_table_1,
+                    topk_indices.new_full(
+                        (
+                            topk_indices.shape[0] - total_extend,
+                            topk_indices.shape[-1],
+                        ),
+                        -1,
+                    ),
+                ],
+                dim=0,
+            )
+        return page_table_1
+
     def _pad_topk_indices(
         self, topk_indices: torch.Tensor, num_tokens: int
     ) -> torch.Tensor:
@@ -2300,6 +2411,7 @@ class NativeSparseAttnBackend(
         force_unfused = forward_batch.hisparse_coordinator is not None and (
             forward_batch.forward_mode.is_decode_or_idle()
             or forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend(include_v2=True)
         )
         return NSAIndexerMetadata(
             attn_metadata=self.forward_metadata,

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -1,7 +1,7 @@
 # to be combined with the sparse coordinator class and sparse algorithm family
 
 import logging
-from typing import List, NamedTuple, Union
+from typing import List, Literal, NamedTuple, Union
 
 import torch
 
@@ -52,6 +52,7 @@ class HiSparseCoordinator:
         device: str,
         tp_group,
         host_to_device_ratio: int = 2,
+        host_allocator_type: str = "default",
     ):
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
@@ -86,6 +87,7 @@ class HiSparseCoordinator:
                 host_size=0,
                 page_size=1,
                 layout="layer_first",
+                allocator_type=host_allocator_type,
                 override_kv_cache_dim=self.mem_pool_device.kv_cache_dim,
             )
             self.item_size_bytes = self.mem_pool_host.token_stride_size
@@ -149,7 +151,7 @@ class HiSparseCoordinator:
             .contiguous()
         )
         self._device_buffer_arange_i32 = torch.arange(
-            self.device_buffer_size, dtype=torch.int32, device=device
+            self.padded_buffer_size, dtype=torch.int32, device=device
         )
 
         # Pre-allocated output buffer for swap_in_selected_pages (CUDA-graph safe)
@@ -327,7 +329,7 @@ class HiSparseCoordinator:
 
         self.req_device_buffer_tokens[
             :, req.req_pool_idx, : self.device_buffer_size
-        ] = self._device_buffer_arange_i32
+        ] = self._device_buffer_arange_i32[: self.device_buffer_size]
         self.req_device_buffer_token_locs[:, req.req_pool_idx, :alloc_size] = (
             buffer_indices[:alloc_size]
         )
@@ -397,6 +399,13 @@ class HiSparseCoordinator:
                     chunk = all_new_indices[offset : offset + grow_size]
                     offset += grow_size
                     self.req_to_device_buffer[req_idx, current_cap:new_cap] = chunk
+                    hot_end = min(new_cap, self.device_buffer_size)
+                    if current_cap < hot_end:
+                        self.req_device_buffer_tokens[
+                            :, req_idx, current_cap:hot_end
+                        ] = self._device_buffer_arange_i32[current_cap:hot_end]
+                    if hot_end < new_cap:
+                        self.req_device_buffer_tokens[:, req_idx, hot_end:new_cap] = -1
                     self.req_device_buffer_token_locs[
                         :, req_idx, current_cap:new_cap
                     ] = chunk
@@ -590,6 +599,417 @@ class HiSparseCoordinator:
         self._backup_done_event.wait(device_module.current_stream())
         self._has_pending_backup = False
 
+    def supports_hisparse_draft_slots(self) -> bool:
+        return not self.is_dsv4_hisparse
+
+    def _ensure_padded_buffer(self, req_pool_indices: torch.Tensor) -> None:
+        """Grow under-sized buffers to padded_buffer_size so extra-page slots are valid."""
+        req_indices_cpu = req_pool_indices.cpu().tolist()
+        grow_reqs = []
+        total_grow = 0
+        for req_idx in req_indices_cpu:
+            current_cap = int(self.req_device_buffer_size[req_idx])
+            if current_cap >= self.padded_buffer_size:
+                continue
+            grow_reqs.append((req_idx, current_cap))
+            total_grow += self.padded_buffer_size - current_cap
+
+        if total_grow == 0:
+            return
+
+        all_new = self.token_to_kv_pool_allocator.hisparse_attn_allocator.alloc(
+            total_grow
+        )
+        if all_new is None:
+            raise RuntimeError(
+                f"HiSparse: failed to grow buffers for draft slots (need {total_grow})"
+            )
+
+        offset = 0
+        for req_idx, current_cap in grow_reqs:
+            grow_size = self.padded_buffer_size - current_cap
+            chunk = all_new[offset : offset + grow_size]
+            offset += grow_size
+            self.req_to_device_buffer[
+                req_idx, current_cap : self.padded_buffer_size
+            ] = chunk
+            hot_end = min(self.padded_buffer_size, self.device_buffer_size)
+            if current_cap < hot_end:
+                self.req_device_buffer_tokens[:, req_idx, current_cap:hot_end] = (
+                    self._device_buffer_arange_i32[current_cap:hot_end]
+                )
+            if hot_end < self.padded_buffer_size:
+                self.req_device_buffer_tokens[
+                    :, req_idx, hot_end : self.padded_buffer_size
+                ] = -1
+            self.req_device_buffer_token_locs[
+                :, req_idx, current_cap : self.padded_buffer_size
+            ] = chunk
+            self.req_device_buffer_size[req_idx] = self.padded_buffer_size
+
+    def get_draft_device_slots(
+        self,
+        req_pool_indices: torch.Tensor,
+        num_tokens_per_req: int,
+        start_positions_cpu: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return device slots for a uniform draft allocation.
+
+        Draft tokens that still fit in the hot buffer reuse their logical hot
+        slots. Later draft tokens use the per-request extra-page area.
+        """
+        assert self.supports_hisparse_draft_slots()
+        start = self.device_buffer_size + 1
+        end = start + num_tokens_per_req
+        if end > self.padded_buffer_size:
+            raise ValueError(
+                f"Requested {num_tokens_per_req} draft slots but extra page only "
+                f"has {self.padded_buffer_size - self.device_buffer_size - 1} "
+                f"available (padded_buffer_size={self.padded_buffer_size}, "
+                f"device_buffer_size={self.device_buffer_size})."
+            )
+        self._ensure_padded_buffer(req_pool_indices)
+        self.req_device_buffer_tokens[
+            :, req_pool_indices, start : self.padded_buffer_size
+        ] = -1
+
+        total_slots = req_pool_indices.numel() * num_tokens_per_req
+        row_indices = torch.repeat_interleave(req_pool_indices, num_tokens_per_req)
+        pos_in_segment = torch.arange(total_slots, device=req_pool_indices.device) % (
+            num_tokens_per_req
+        )
+        start_positions = start_positions_cpu.to(
+            device=req_pool_indices.device, dtype=torch.int64
+        )
+        token_positions = (
+            torch.repeat_interleave(start_positions, num_tokens_per_req)
+            + pos_in_segment
+        )
+        col_indices = torch.where(
+            token_positions < self.device_buffer_size,
+            token_positions,
+            start + pos_in_segment,
+        )
+        if torch.any(col_indices >= self.padded_buffer_size):
+            raise ValueError(
+                "HiSparse draft slots exceed padded buffer: "
+                f"{col_indices.max().item()=} {self.padded_buffer_size=}"
+            )
+        self.req_device_buffer_tokens[:, row_indices, col_indices] = token_positions.to(
+            torch.int32
+        ).unsqueeze(0)
+        return self.req_to_device_buffer[row_indices, col_indices]
+
+    def get_draft_device_slots_variable(
+        self,
+        req_pool_indices: torch.Tensor,
+        tokens_per_req_cpu: torch.Tensor,
+        start_positions_cpu: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return device slots when each request needs a different draft count."""
+        assert self.supports_hisparse_draft_slots()
+        if tokens_per_req_cpu.numel() == 0:
+            return torch.empty(0, dtype=torch.int64, device=req_pool_indices.device)
+
+        start = self.device_buffer_size + 1
+        max_tokens = int(tokens_per_req_cpu.max().item())
+        if start + max_tokens > self.padded_buffer_size:
+            raise ValueError(
+                f"Max per-request draft slots ({max_tokens}) exceeds extra page "
+                f"capacity ({self.padded_buffer_size - self.device_buffer_size - 1})."
+            )
+
+        self._ensure_padded_buffer(req_pool_indices)
+        self.req_device_buffer_tokens[
+            :, req_pool_indices, start : self.padded_buffer_size
+        ] = -1
+
+        total_slots = int(tokens_per_req_cpu.sum().item())
+        if total_slots == 0:
+            return torch.empty(0, dtype=torch.int64, device=req_pool_indices.device)
+
+        tokens_per_req = tokens_per_req_cpu.to(
+            device=req_pool_indices.device, dtype=torch.int64
+        )
+
+        # Build fixed-shape gather indices. Zero-repeat requests naturally disappear.
+        row_indices = torch.repeat_interleave(req_pool_indices, tokens_per_req)
+        offsets = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.int64, device=tokens_per_req.device),
+                tokens_per_req.cumsum(0),
+            ]
+        )
+        pos_in_segment = torch.arange(total_slots, device=tokens_per_req.device) - (
+            torch.repeat_interleave(offsets[:-1], tokens_per_req)
+        )
+
+        start_positions = start_positions_cpu.to(
+            device=req_pool_indices.device, dtype=torch.int64
+        )
+        token_positions = torch.repeat_interleave(start_positions, tokens_per_req) + (
+            pos_in_segment
+        )
+        col_indices = torch.where(
+            token_positions < self.device_buffer_size,
+            token_positions,
+            start + pos_in_segment,
+        )
+        if torch.any(col_indices >= self.padded_buffer_size):
+            raise ValueError(
+                "HiSparse variable draft slots exceed padded buffer: "
+                f"{col_indices.max().item()=} {self.padded_buffer_size=}"
+            )
+
+        self.req_device_buffer_tokens[:, row_indices, col_indices] = token_positions.to(
+            torch.int32
+        ).unsqueeze(0)
+        return self.req_to_device_buffer[row_indices, col_indices]
+
+    def prepare_verify_slots_spec_v2(
+        self,
+        req_pool_indices: torch.Tensor,
+        verify_cache_locs: torch.Tensor,
+        num_tokens_per_req: int,
+        start_positions_cpu: torch.Tensor,
+    ) -> None:
+        """Bind the current spec-v2 target-verify window to extra-page slots."""
+        assert self.supports_hisparse_draft_slots()
+        start = self.device_buffer_size + 1
+        end = start + num_tokens_per_req
+        if end > self.padded_buffer_size:
+            raise ValueError(
+                f"Spec-v2 verify needs {num_tokens_per_req} slots but extra page only "
+                f"has {self.padded_buffer_size - self.device_buffer_size - 1}."
+            )
+
+        self._ensure_padded_buffer(req_pool_indices)
+        self.req_device_buffer_tokens[
+            :, req_pool_indices, start : self.padded_buffer_size
+        ] = -1
+
+        total_slots = req_pool_indices.numel() * num_tokens_per_req
+        if verify_cache_locs.numel() != total_slots:
+            raise ValueError(
+                "HiSparse spec-v2 verify slot mismatch: "
+                f"expected {total_slots} cache locs, got {verify_cache_locs.numel()}."
+            )
+
+        row_indices = torch.repeat_interleave(req_pool_indices, num_tokens_per_req)
+        pos_in_segment = torch.arange(total_slots, device=req_pool_indices.device) % (
+            num_tokens_per_req
+        )
+        start_positions = start_positions_cpu.to(
+            device=req_pool_indices.device, dtype=torch.int64
+        )
+        token_positions = (
+            torch.repeat_interleave(start_positions, num_tokens_per_req)
+            + pos_in_segment
+        )
+        col_indices = torch.where(
+            token_positions < self.device_buffer_size,
+            token_positions,
+            start + pos_in_segment,
+        )
+        device_slots = self.req_to_device_buffer[row_indices, col_indices]
+        self.req_device_buffer_tokens[:, row_indices, col_indices] = token_positions.to(
+            torch.int32
+        ).unsqueeze(0)
+        self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping[
+            verify_cache_locs
+        ] = device_slots
+
+    def finalize_accepted_tokens(
+        self,
+        req_pool_indices: torch.Tensor,
+        accepted_cache_locs: torch.Tensor,
+        draft_cache_locs: torch.Tensor,
+        num_correct_drafts: torch.Tensor,
+        num_correct_drafts_cpu: torch.Tensor,
+        accepted_token_positions: torch.Tensor,
+    ) -> None:
+        """Persist accepted speculative tokens and remap the newest token slot.
+
+        Accepted draft tokens inside the hot buffer keep their hot slots. Tokens
+        beyond the hot buffer are backed up to host, while the last accepted
+        token is copied into the newest-token slot for the next decode step.
+
+        Transactional: if host alloc fails, all mapping mutations are rolled back
+        so the coordinator stays consistent for the next iteration.
+        """
+        assert self.supports_hisparse_draft_slots()
+        if accepted_cache_locs.numel() == 0:
+            return
+
+        counts = num_correct_drafts.to(torch.int64) + 1
+        counts_cpu = num_correct_drafts_cpu.to(torch.int64) + 1
+        total_accepted = int(counts_cpu.sum().item())
+        if total_accepted != accepted_cache_locs.numel():
+            raise ValueError(
+                "HiSparse accepted token bookkeeping mismatch: "
+                f"expected {total_accepted} cache locs, got {accepted_cache_locs.numel()}."
+            )
+        if total_accepted != accepted_token_positions.numel():
+            raise ValueError(
+                "HiSparse accepted token position mismatch: "
+                f"expected {total_accepted} positions, "
+                f"got {accepted_token_positions.numel()}."
+            )
+
+        full_to_device_mapping = (
+            self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+        )
+        accepted_token_positions = accepted_token_positions.to(
+            device=accepted_cache_locs.device, dtype=torch.int64
+        )
+        in_hot_buffer = accepted_token_positions < self.device_buffer_size
+
+        # Snapshot mapping values before mutation for rollback.
+        draft_mapping_snapshot = full_to_device_mapping[draft_cache_locs].clone()
+        accepted_device_locs = full_to_device_mapping[accepted_cache_locs].clone()
+
+        full_to_device_mapping[draft_cache_locs] = 0
+        accepted_req_indices = torch.repeat_interleave(req_pool_indices, counts)
+        if torch.any(in_hot_buffer):
+            hot_cache_locs = accepted_cache_locs[in_hot_buffer]
+            hot_positions = accepted_token_positions[in_hot_buffer]
+            hot_req_indices = accepted_req_indices[in_hot_buffer]
+            hot_slots = self.req_to_device_buffer[hot_req_indices, hot_positions]
+            full_to_device_mapping[hot_cache_locs] = hot_slots
+
+        needs_backup = ~in_hot_buffer
+        backup_count = int(needs_backup.sum().item())
+        if backup_count > 0:
+            backup_positions = accepted_token_positions[needs_backup]
+            backup_req_indices = accepted_req_indices[needs_backup]
+            backup_device_locs = accepted_device_locs[needs_backup]
+
+            host_locs = self.mem_pool_host.alloc(backup_count)
+            if host_locs is None:
+                full_to_device_mapping[draft_cache_locs] = draft_mapping_snapshot
+                logger.error(
+                    "HiSparse: host alloc failed for %d accepted draft tokens, rolled back",
+                    backup_count,
+                )
+                return
+            host_locs = host_locs.to(device=self.device)
+
+            self.wait_for_pending_backup()
+            schedule_stream = device_module.current_stream()
+            device_locs_for_backup = backup_device_locs.contiguous()
+            with device_module.stream(self.decode_backup_stream):
+                self.decode_backup_stream.wait_stream(schedule_stream)
+                self.mem_pool_host.backup_from_device_all_layer(
+                    self.mem_pool_device,
+                    host_locs,
+                    device_locs_for_backup,
+                    io_backend="kernel",
+                )
+                if host_locs.is_cuda:
+                    host_locs.record_stream(self.decode_backup_stream)
+                if device_locs_for_backup.is_cuda:
+                    device_locs_for_backup.record_stream(self.decode_backup_stream)
+            event = device_module.Event()
+            event.record(self.decode_backup_stream)
+            device_module.current_stream().wait_event(event)
+
+            self.req_to_host_pool[backup_req_indices, backup_positions] = host_locs
+
+        offsets = torch.cat(
+            [torch.zeros(1, dtype=torch.int64, device=counts.device), counts.cumsum(0)]
+        )
+        last_offsets = offsets[1:] - 1
+        last_positions = accepted_token_positions[last_offsets]
+        newest_slots = self.req_to_device_buffer[
+            req_pool_indices, self.device_buffer_size
+        ]
+        last_logical = accepted_cache_locs[last_offsets]
+        last_slots = accepted_device_locs[last_offsets]
+        self.req_device_buffer_tokens[:, req_pool_indices, self.device_buffer_size] = (
+            last_positions.to(torch.int32).unsqueeze(0)
+        )
+        self.req_device_buffer_token_locs[
+            :, req_pool_indices, self.device_buffer_size
+        ] = newest_slots.to(torch.int32)
+        for idx in req_pool_indices.tolist():
+            self._skip_first_backup[idx] = True
+
+        same_slot = last_slots == newest_slots
+        if torch.any(~same_slot):
+            self.mem_pool_device.transfer_values_on_device(
+                dst_indices=newest_slots[~same_slot],
+                src_indices=last_slots[~same_slot],
+            )
+        full_to_device_mapping[last_logical] = newest_slots
+
+    def finalize_accepted_tokens_spec_v2(
+        self,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        verify_cache_locs: torch.Tensor,
+        accept_index: torch.Tensor,
+    ) -> None:
+        """Commit accepted spec-v2 target-verify KV into HiSparse storage.
+
+        The target verify pass writes all draft-token KV into per-request
+        extra-page slots. accept_index is the source of truth for which slots
+        survive into host/newest-slot metadata.
+        """
+        assert self.supports_hisparse_draft_slots()
+        if verify_cache_locs.numel() == 0:
+            return
+
+        counts = (accept_index != -1).sum(dim=1).to(torch.int64)
+        total_accepted = int(counts.sum().item())
+        if total_accepted == 0:
+            full_to_device_mapping = (
+                self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+            )
+            full_to_device_mapping[verify_cache_locs] = 0
+            return
+
+        flat_accept_index = accept_index.reshape(-1)
+        accepted_offsets = flat_accept_index[flat_accept_index >= 0].to(torch.int64)
+        if accepted_offsets.numel() != total_accepted:
+            raise ValueError(
+                "HiSparse spec-v2 accepted index mismatch: "
+                f"expected {total_accepted} accepted slots, "
+                f"got {accepted_offsets.numel()}."
+            )
+
+        offsets = torch.cat(
+            [torch.zeros(1, dtype=torch.int64, device=counts.device), counts.cumsum(0)]
+        )
+        pos_in_segment = torch.arange(
+            total_accepted, dtype=torch.int64, device=counts.device
+        ) - torch.repeat_interleave(offsets[:-1], counts)
+        accepted_token_positions = (
+            torch.repeat_interleave(seq_lens.to(torch.int64), counts) + pos_in_segment
+        )
+
+        self.finalize_accepted_tokens(
+            req_pool_indices=req_pool_indices,
+            accepted_cache_locs=verify_cache_locs[accepted_offsets],
+            draft_cache_locs=verify_cache_locs,
+            num_correct_drafts=counts - 1,
+            num_correct_drafts_cpu=(counts - 1).cpu(),
+            accepted_token_positions=accepted_token_positions,
+        )
+
+    def get_front_topk_tokens(
+        self,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> torch.Tensor:
+        top_k_indices = self.req_to_device_buffer[req_pool_indices, : self.top_k].to(
+            torch.int32
+        )
+        topk_col_indices = torch.arange(self.top_k, device=self.device).unsqueeze(0)
+        # Mask out positions beyond each request's seq_len
+        mask = topk_col_indices >= seq_lens.unsqueeze(1)
+        top_k_indices[mask] = -1
+        return top_k_indices
+
     def naive_load_topk(
         self,
         req_pool_indices: torch.Tensor,
@@ -768,14 +1188,65 @@ class HiSparseCoordinator:
         compressed_seq_lens: torch.Tensor,
         top_k_result: torch.Tensor,
         layer_id: int,
+        token_position_space: Literal["compressed", "full"] = "compressed",
+        num_steps: int = 1,
     ) -> torch.Tensor:
-        """Swap selected top-k tokens into device memory and return their indices."""
-        num_reqs = req_pool_indices.size(0)
+        """Swap selected top-k tokens into device memory and return their indices.
 
-        top_k_indices = self.top_k_device_locs_buffer[:num_reqs]
+        When num_steps > 1 (speculative multi-step):
+            seq_lens shape: [num_reqs * num_steps] flat req-major
+            top_k_result shape: [num_reqs, num_steps, top_k]
+            returns: [num_reqs, num_steps, top_k]
+        """
+        num_reqs = req_pool_indices.size(0)
+        needed = num_reqs * num_steps
+
+        if needed > self.top_k_device_locs_buffer.shape[0]:
+            self.top_k_device_locs_buffer = torch.full(
+                (needed, self.top_k),
+                -1,
+                dtype=torch.int32,
+                device=self.device,
+            )
+
+        if num_steps > 1:
+            top_k_indices = self.top_k_device_locs_buffer[:needed].view(
+                num_reqs, num_steps, -1
+            )
+        else:
+            top_k_indices = self.top_k_device_locs_buffer[:num_reqs]
         top_k_indices.fill_(-1)
 
-        # todo, adjustable for performance
+        swap_seq_lens = compressed_seq_lens
+        swap_top_k_result = top_k_result
+        if token_position_space == "full" and self.is_dsv4_hisparse:
+            if num_steps > 1:
+                seq_lens_for_compare = compressed_seq_lens.view(
+                    num_reqs, num_steps
+                ).unsqueeze(2)
+            else:
+                seq_lens_for_compare = compressed_seq_lens.unsqueeze(1)
+            valid_compressed_token = (
+                (top_k_result >= 0)
+                & (top_k_result < seq_lens_for_compare)
+                & ((top_k_result + 1) % self.compress_ratio == 0)
+            )
+            swap_top_k_result = torch.where(
+                valid_compressed_token,
+                top_k_result // self.compress_ratio,
+                torch.full_like(top_k_result, -1),
+            )
+            if num_steps > 1:
+                swap_seq_lens = (
+                    compressed_seq_lens.view(num_reqs, num_steps) // self.compress_ratio
+                ).reshape(-1)
+            else:
+                swap_seq_lens = compressed_seq_lens // self.compress_ratio
+        elif token_position_space != "compressed":
+            assert (
+                token_position_space == "full"
+            ), f"Unsupported token_position_space={token_position_space}"
+
         block_size = 1024
         swap_in_fn = (
             load_cache_to_device_buffer_dsv4_mla
@@ -783,7 +1254,7 @@ class HiSparseCoordinator:
             else load_cache_to_device_buffer_mla
         )
         swap_in_fn(
-            top_k_tokens=top_k_result,
+            top_k_tokens=swap_top_k_result,
             device_buffer_tokens=self.req_device_buffer_tokens[layer_id],
             host_cache_locs=self.req_to_host_pool,
             device_buffer_locs=self.req_device_buffer_token_locs[layer_id],
@@ -791,13 +1262,14 @@ class HiSparseCoordinator:
             device_buffer=self.mem_pool_device.kv_buffer[layer_id],
             top_k_device_locs=top_k_indices,
             req_pool_indices=req_pool_indices,
-            seq_lens=compressed_seq_lens,
+            seq_lens=swap_seq_lens,
             lru_slots=self.lru_slots[layer_id],
             item_size_bytes=self.item_size_bytes,
             num_top_k=self.top_k,
             hot_buffer_size=self.device_buffer_size,
-            page_size=1,
+            page_size=self.mem_pool_device.page_size if num_steps > 1 else 1,
             block_size=block_size,
             num_real_reqs=self.num_real_reqs,
+            num_steps=num_steps,
         )
         return top_k_indices

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -1193,17 +1193,12 @@ class HiSparseCoordinator:
         self._skip_first_backup[req.req_pool_idx] = False
         req.hisparse_staging = False
 
-    def retract_req(self, req: Req) -> None:
-        if req.hisparse_staging:
-            self.abort_staging_request(req)
-        else:
-            self.request_finished(req)
-
-    def request_finished(self, req: Req):
+    def _clear_req_device_state(self, req: Req) -> int:
         # release resources only after the execution of a potential overlapped batch
         if self.decode_producer_stream is not None:
             device_module.current_stream().wait_stream(self.decode_producer_stream)
         self.wait_for_pending_backup()
+        req_idx = self._req_pool_idx(req)
 
         # Use kv_allocated_len (not seqlen): under speculative decoding the
         # allocator can over-allocate beyond the committed seqlen, and those
@@ -1215,34 +1210,158 @@ class HiSparseCoordinator:
         compressed_len = allocated_len // self.compress_ratio
 
         # release memory -- only free actually-allocated buffer indices
-        current_cap = int(self.req_device_buffer_size[req.req_pool_idx])
+        current_cap = int(self.req_device_buffer_size[req_idx])
         if current_cap > 0:
-            side_buf_hi = self.req_to_device_buffer[req.req_pool_idx, :current_cap]
+            side_buf_hi = self.req_to_device_buffer[req_idx, :current_cap]
             all_hi = torch.unique(side_buf_hi[side_buf_hi > 0])
             if all_hi.numel() > 0:
                 self.token_to_kv_pool_allocator.free_hisparse_indices(all_hi)
 
-        allocated_locs = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, :allocated_len
-        ]
+        allocated_locs = self.req_to_token_pool.req_to_token[req_idx, :allocated_len]
         compressed_locs = self.mem_pool_device.translate_loc_from_full_to_compressed(
             allocated_locs
         )
         self.mem_pool_device.full_to_hisparse_device_index_mapping[compressed_locs] = 0
 
-        host_indices = self.req_to_host_pool[req.req_pool_idx, :compressed_len]
+        # clear req info
+        self.req_device_buffer_tokens[:, req_idx, :] = -1
+        self.req_device_buffer_token_locs[:, req_idx, :] = -1
+        self.req_to_device_buffer[req_idx, :] = 0
+        self.req_device_buffer_size[req_idx] = 0
+        self.lru_slots[:, req_idx, :].copy_(self._lru_init)
+        self._skip_first_backup[req_idx] = False
+        return compressed_len
+
+    def _free_host_indices(self, host_indices: torch.Tensor) -> None:
         host_indices = host_indices[host_indices >= 0]
         if host_indices.numel() > 0:
             self.mem_pool_host.free(host_indices)
 
-        # clear req info
-        self.req_device_buffer_tokens[:, req.req_pool_idx, :] = -1
-        self.req_device_buffer_token_locs[:, req.req_pool_idx, :] = -1
-        self.req_to_device_buffer[req.req_pool_idx, :] = 0
-        self.req_device_buffer_size[req.req_pool_idx] = 0
+    @staticmethod
+    def _req_pool_idx(req: Req) -> int:
+        req_idx = req.req_pool_idx
+        if isinstance(req_idx, torch.Tensor):
+            if req_idx.numel() != 1:
+                raise ValueError(
+                    f"HiSparse req {req.rid} has non-scalar req_pool_idx: "
+                    f"shape={tuple(req_idx.shape)} value={req_idx}"
+                )
+            req_idx = int(req_idx.item())
+            req.req_pool_idx = req_idx
+        return req_idx
+
+    def _clear_retracted_host_indices(self, req: Req) -> None:
+        if hasattr(req, "hisparse_retracted_host_indices"):
+            del req.hisparse_retracted_host_indices
+        if hasattr(req, "hisparse_retracted_host_len"):
+            del req.hisparse_retracted_host_len
+
+    def release_retracted_req(self, req: Req) -> None:
+        host_indices = getattr(req, "hisparse_retracted_host_indices", None)
+        if host_indices is not None:
+            self._free_host_indices(host_indices)
+        self._clear_retracted_host_indices(req)
+
+    def pop_retracted_host_indices(
+        self, req: Req, host_len: int
+    ) -> Union[torch.Tensor, None]:
+        host_indices = getattr(req, "hisparse_retracted_host_indices", None)
+        if host_indices is None:
+            return None
+        if host_indices.numel() < host_len:
+            raise RuntimeError(
+                f"HiSparse retracted host indices too short for req {req.rid}: "
+                f"{host_indices.numel()} < {host_len}"
+            )
+
+        restored_indices = host_indices[:host_len].to(device=self.device)
+        self._free_host_indices(host_indices[host_len:])
+        self._clear_retracted_host_indices(req)
+        return restored_indices
+
+    def _ensure_host_backed(self, req: Req, preserve_len: int, host_len: int) -> bool:
+        host_indices = self.req_to_host_pool[req.req_pool_idx, :host_len]
+        missing_positions = torch.nonzero(host_indices < 0, as_tuple=False).flatten()
+        if missing_positions.numel() == 0:
+            return True
+
+        if self.compress_ratio == 1:
+            full_positions = missing_positions
+        else:
+            full_positions = missing_positions * self.compress_ratio + (
+                self.compress_ratio - 1
+            )
+            if torch.any(full_positions >= preserve_len):
+                logger.warning(
+                    "HiSparse cannot retract req %s: compressed host positions map "
+                    "past preserve_len (%s >= %s)",
+                    req.rid,
+                    full_positions.tolist(),
+                    preserve_len,
+                )
+                return False
+
+        logical_locs = self.req_to_token_pool.req_to_token[
+            req.req_pool_idx, full_positions
+        ]
+        compressed_locs = self.mem_pool_device.translate_loc_from_full_to_compressed(
+            logical_locs
+        )
+        device_locs = self.mem_pool_device.full_to_hisparse_device_index_mapping[
+            compressed_locs
+        ]
+        if torch.any(device_locs <= 0):
+            bad_positions = missing_positions[device_locs <= 0].tolist()
+            logger.warning(
+                "HiSparse cannot retract req %s: host backup is missing and no "
+                "live device mapping exists for positions %s",
+                req.rid,
+                bad_positions,
+            )
+            return False
+
+        new_host_indices = self.mem_pool_host.alloc(missing_positions.numel())
+        if new_host_indices is None:
+            logger.warning(
+                "HiSparse cannot retract req %s: host mem pool alloc failed for "
+                "%d backup tokens, available=%d",
+                req.rid,
+                missing_positions.numel(),
+                self.mem_pool_host.available_size(),
+            )
+            return False
+        new_host_indices = new_host_indices.to(device=self.device)
+        self._backup_device_locs_to_host(new_host_indices, device_locs)
+        self.req_to_host_pool[req.req_pool_idx, missing_positions] = new_host_indices
+        return True
+
+    def retract_req(self, req: Req) -> bool:
+        if req.hisparse_staging:
+            self.abort_staging_request(req)
+            return True
+
+        preserve_len = len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
+        compressed_len = preserve_len // self.compress_ratio
+        stale_host_indices = self.req_to_host_pool[req.req_pool_idx, compressed_len:]
+        self._free_host_indices(stale_host_indices)
+        self.req_to_host_pool[req.req_pool_idx, compressed_len:] = -1
+        if not self._ensure_host_backed(req, preserve_len, compressed_len):
+            return False
+        req.hisparse_retracted_host_indices = self.req_to_host_pool[
+            req.req_pool_idx, :compressed_len
+        ].clone()
+        req.hisparse_retracted_host_len = compressed_len
+        self._clear_req_device_state(req)
         self.req_to_host_pool[req.req_pool_idx, :] = -1
-        self.lru_slots[:, req.req_pool_idx, :].copy_(self._lru_init)
-        self._skip_first_backup[req.req_pool_idx] = False
+        return True
+
+    def request_finished(self, req: Req):
+        compressed_len = self._clear_req_device_state(req)
+
+        host_indices = self.req_to_host_pool[req.req_pool_idx, :compressed_len]
+        self._free_host_indices(host_indices)
+        self.req_to_host_pool[req.req_pool_idx, :] = -1
+        self._clear_retracted_host_indices(req)
 
     def swap_in_selected_pages(
         self,

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -168,6 +168,7 @@ class HiSparseCoordinator:
         # CPU flag: True means "skip backup on the next decode step" because
         # staging already backed up all prefill tokens.  Cleared after one step.
         self._skip_first_backup = [False] * max_num_req_slots
+        self._pending_draft_extend_backup = None
 
     def set_decode_producer_stream(self, stream) -> None:
         self.decode_producer_stream = stream
@@ -467,6 +468,9 @@ class HiSparseCoordinator:
             self.req_device_buffer_token_locs[
                 :, req_pool_indices, self.device_buffer_size
             ] = reserved_buffer_loc.to(torch.int32)
+            self.req_device_buffer_tokens[
+                :, req_pool_indices, self.device_buffer_size
+            ] = (seq_lens.to(torch.int32) - 1)
 
             # No need to clear prior mappings: the only consumer of the mapping
             # for past tokens is the swap-in kernel, and it goes through
@@ -598,6 +602,57 @@ class HiSparseCoordinator:
             return
         self._backup_done_event.wait(device_module.current_stream())
         self._has_pending_backup = False
+
+    def _backup_device_locs_to_host(
+        self, host_locs: torch.Tensor, device_locs: torch.Tensor
+    ) -> None:
+        if host_locs.numel() == 0:
+            return
+        self.wait_for_pending_backup()
+        schedule_stream = device_module.current_stream()
+        device_locs = device_locs.contiguous()
+        with device_module.stream(self.decode_backup_stream):
+            self.decode_backup_stream.wait_stream(schedule_stream)
+            if self.decode_producer_stream is not None:
+                self.decode_backup_stream.wait_stream(self.decode_producer_stream)
+            self.mem_pool_host.backup_from_device_all_layer(
+                self.mem_pool_device,
+                host_locs,
+                device_locs,
+                io_backend="kernel",
+            )
+            if host_locs.is_cuda:
+                host_locs.record_stream(self.decode_backup_stream)
+            if device_locs.is_cuda:
+                device_locs.record_stream(self.decode_backup_stream)
+        event = device_module.Event()
+        event.record(self.decode_backup_stream)
+        device_module.current_stream().wait_event(event)
+
+    def finish_pending_draft_extend_backup(self) -> None:
+        pending = self._pending_draft_extend_backup
+        if pending is None:
+            return
+        self._pending_draft_extend_backup = None
+        host_locs, device_locs, logical_locs_to_clear = pending
+        self._backup_device_locs_to_host(host_locs, device_locs)
+        if logical_locs_to_clear.numel() > 0:
+            full_to_device_mapping = (
+                self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+            )
+            full_to_device_mapping[logical_locs_to_clear] = 0
+
+    def clear_pending_draft_extend_backup(self) -> None:
+        pending = self._pending_draft_extend_backup
+        if pending is None:
+            return
+        self._pending_draft_extend_backup = None
+        _, _, logical_locs_to_clear = pending
+        if logical_locs_to_clear.numel() > 0:
+            full_to_device_mapping = (
+                self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+            )
+            full_to_device_mapping[logical_locs_to_clear] = 0
 
     def supports_hisparse_draft_slots(self) -> bool:
         return not self.is_dsv4_hisparse
@@ -840,6 +895,7 @@ class HiSparseCoordinator:
         assert self.supports_hisparse_draft_slots()
         if accepted_cache_locs.numel() == 0:
             return
+        self.clear_pending_draft_extend_backup()
 
         counts = num_correct_drafts.to(torch.int64) + 1
         counts_cpu = num_correct_drafts_cpu.to(torch.int64) + 1
@@ -894,43 +950,27 @@ class HiSparseCoordinator:
                 return
             host_locs = host_locs.to(device=self.device)
 
-            self.wait_for_pending_backup()
-            schedule_stream = device_module.current_stream()
-            device_locs_for_backup = backup_device_locs.contiguous()
-            with device_module.stream(self.decode_backup_stream):
-                self.decode_backup_stream.wait_stream(schedule_stream)
-                self.mem_pool_host.backup_from_device_all_layer(
-                    self.mem_pool_device,
-                    host_locs,
-                    device_locs_for_backup,
-                    io_backend="kernel",
-                )
-                if host_locs.is_cuda:
-                    host_locs.record_stream(self.decode_backup_stream)
-                if device_locs_for_backup.is_cuda:
-                    device_locs_for_backup.record_stream(self.decode_backup_stream)
-            event = device_module.Event()
-            event.record(self.decode_backup_stream)
-            device_module.current_stream().wait_event(event)
-
+            self._backup_device_locs_to_host(host_locs, backup_device_locs)
             self.req_to_host_pool[backup_req_indices, backup_positions] = host_locs
+            full_to_device_mapping[accepted_cache_locs[needs_backup]] = (
+                backup_device_locs
+            )
 
         offsets = torch.cat(
             [torch.zeros(1, dtype=torch.int64, device=counts.device), counts.cumsum(0)]
         )
         last_offsets = offsets[1:] - 1
         last_positions = accepted_token_positions[last_offsets]
-        newest_slots = self.req_to_device_buffer[
-            req_pool_indices, self.device_buffer_size
-        ]
+        reserved_positions = last_positions.clamp(max=self.device_buffer_size)
+        newest_slots = self.req_to_device_buffer[req_pool_indices, reserved_positions]
         last_logical = accepted_cache_locs[last_offsets]
         last_slots = accepted_device_locs[last_offsets]
-        self.req_device_buffer_tokens[:, req_pool_indices, self.device_buffer_size] = (
+        self.req_device_buffer_tokens[:, req_pool_indices, reserved_positions] = (
             last_positions.to(torch.int32).unsqueeze(0)
         )
-        self.req_device_buffer_token_locs[
-            :, req_pool_indices, self.device_buffer_size
-        ] = newest_slots.to(torch.int32)
+        self.req_device_buffer_token_locs[:, req_pool_indices, reserved_positions] = (
+            newest_slots.to(torch.int32)
+        )
         for idx in req_pool_indices.tolist():
             self._skip_first_backup[idx] = True
 
@@ -941,6 +981,28 @@ class HiSparseCoordinator:
                 src_indices=last_slots[~same_slot],
             )
         full_to_device_mapping[last_logical] = newest_slots
+
+        if backup_count > 0:
+            backup_positions_in_needs = (
+                torch.cumsum(needs_backup.to(torch.int64), dim=0) - 1
+            )
+            last_needs_backup = needs_backup[last_offsets]
+            post_backup_device_locs = backup_device_locs.clone()
+            if torch.any(last_needs_backup):
+                last_backup_offsets = backup_positions_in_needs[
+                    last_offsets[last_needs_backup]
+                ]
+                post_backup_device_locs[last_backup_offsets] = newest_slots[
+                    last_needs_backup
+                ]
+
+            logical_locs_to_clear_mask = needs_backup.clone()
+            logical_locs_to_clear_mask[last_offsets] = False
+            self._pending_draft_extend_backup = (
+                host_locs,
+                post_backup_device_locs,
+                accepted_cache_locs[logical_locs_to_clear_mask],
+            )
 
     def finalize_accepted_tokens_spec_v2(
         self,

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -190,6 +190,41 @@ class HiSparseCoordinator:
             ),
         )
 
+    def compressed_host_len(self, full_len: int) -> int:
+        """Number of host slots needed for a committed full-token length."""
+        return max(0, full_len) // self.compress_ratio
+
+    def host_decode_reserve_len(self, full_len: int, num_decode_tokens: int) -> int:
+        """Extra host slots needed to keep decoding for `num_decode_tokens`."""
+        if num_decode_tokens <= 0:
+            return 0
+        return self.compressed_host_len(full_len + num_decode_tokens) - (
+            self.compressed_host_len(full_len)
+        )
+
+    def host_tokens_required_next_decode(
+        self, reqs: List[Req], speculative_token_budget: int = 0
+    ) -> int:
+        """Host slots that may be newly allocated by the next decode iteration.
+
+        `speculative_token_budget` is host-specific: it should cover accepted
+        draft tokens that may be backed up to host, not the full GPU draft KV
+        allocation used to run speculative verification.
+        """
+        required = 0
+        for req in reqs:
+            req_idx = self._req_pool_idx(req)
+            if self._skip_first_backup[req_idx]:
+                continue
+
+            seq_len = getattr(req, "kv_committed_len", None)
+            if seq_len is None:
+                seq_len = len(req.origin_input_ids) + len(req.output_ids)
+            if seq_len % self.compress_ratio == 0:
+                required += 1
+
+        return required + max(0, speculative_token_budget)
+
     def admit_request_into_staging(self, req: Req) -> None:
         req.hisparse_staging = True
 
@@ -1184,7 +1219,7 @@ class HiSparseCoordinator:
         self.token_to_kv_pool_allocator.free_hisparse(allocated_locs)
 
         # Free host memory that was allocated during admit_request_into_staging
-        compressed_len = prefill_len // self.compress_ratio
+        compressed_len = self.compressed_host_len(prefill_len)
         host_indices = self.req_to_host_pool[req.req_pool_idx, :compressed_len]
         host_indices = host_indices[host_indices >= 0]
         if host_indices.numel() > 0:
@@ -1207,7 +1242,7 @@ class HiSparseCoordinator:
         # subsequent release_kv_cache -> allocator.free -> free_hisparse path
         # re-frees them (double-free into the page allocator's free list).
         allocated_len = req.kv_allocated_len
-        compressed_len = allocated_len // self.compress_ratio
+        compressed_len = self.compressed_host_len(allocated_len)
 
         # release memory -- only free actually-allocated buffer indices
         current_cap = int(self.req_device_buffer_size[req_idx])
@@ -1341,7 +1376,7 @@ class HiSparseCoordinator:
             return True
 
         preserve_len = len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
-        compressed_len = preserve_len // self.compress_ratio
+        compressed_len = self.compressed_host_len(preserve_len)
         stale_host_indices = self.req_to_host_pool[req.req_pool_idx, compressed_len:]
         self._free_host_indices(stale_host_indices)
         self.req_to_host_pool[req.req_pool_idx, compressed_len:] = -1

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1980,6 +1980,9 @@ class DisaggregationMetrics:
     """PD disaggregation metrics."""
 
     mode: str  # "prefill", "decode", or "null" - not a metric
+    prefill_pending_queue_reqs: int = field(
+        default=0, metadata={"metric": ("gauge", "Prefill pending queue requests")}
+    )
     prefill_bootstrap_queue_reqs: int = field(
         default=0, metadata={"metric": ("gauge", "Prefill bootstrap queue requests")}
     )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -909,6 +909,7 @@ class Req(ReqDllmMixin):
 
         # For hisparse
         self.hisparse_staging = False
+        self.hisparse_spec_info = None
 
     @property
     def seqlen(self) -> int:
@@ -1266,6 +1267,7 @@ class Req(ReqDllmMixin):
         self.kv_committed_len = 0
         self.kv_committed_freed = False
         self.kv_overallocated_freed = False
+        self.hisparse_spec_info = None
         self.swa_evicted_seqlen = 0
         self.extend_batch_idx = 0
         self.decode_batch_idx = 0
@@ -2613,6 +2615,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             mamba_track_indices=self.mamba_track_indices,
             mamba_track_mask=self.mamba_track_mask,
             mamba_track_seqlens=self.mamba_track_seqlens,
+            hisparse_coordinator=self.hisparse_coordinator,
         )
 
     def copy(self):
@@ -2852,3 +2855,6 @@ class ModelWorkerBatch:
     mamba_track_indices: Optional[torch.Tensor] = None  # shape: [b], int64
     mamba_track_mask: Optional[torch.Tensor] = None  # shape: [b], bool
     mamba_track_seqlens: Optional[torch.Tensor] = None  # shape: [b], int64
+
+    # HiSparse
+    hisparse_coordinator: Optional[HiSparseCoordinator] = None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2138,6 +2138,29 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         num_tokens = max(len_per_topk * spec_topk, spec_tokens) * len(requests)
         return num_tokens
 
+    def _host_tokens_required_next_decode_spec(self, requests: List[Req]) -> int:
+        if (
+            self.hisparse_coordinator is None
+            or self.spec_algorithm.is_none()
+            or not self.hisparse_coordinator.supports_hisparse_draft_slots()
+        ):
+            return 0
+
+        server_args = get_global_server_args()
+        if self.is_spec_v2:
+            from sglang.srt.managers.utils import get_alloc_len_per_decode
+
+            max_accepted_tokens = get_alloc_len_per_decode() + 1
+        else:
+            max_accepted_tokens = (
+                max(
+                    server_args.speculative_num_steps or 0,
+                    server_args.speculative_num_draft_tokens or 0,
+                )
+                + 1
+            )
+        return max_accepted_tokens * len(requests)
+
     def _new_tokens_required_next_decode_spec_v2(self, requests, page_size):
         """Tight estimate matching eagle_info_v2.prepare_for_decode allocation."""
         from sglang.srt.managers.utils import get_alloc_len_per_decode
@@ -2154,7 +2177,24 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     def check_decode_mem(self, selected_indices: Optional[List[int]] = None):
         num_tokens = self.new_tokens_required_next_decode(selected_indices)
         evict_from_tree_cache(self.tree_cache, num_tokens)
-        return self.token_to_kv_pool_allocator.available_size() >= num_tokens
+        if self.token_to_kv_pool_allocator.available_size() < num_tokens:
+            return False
+
+        if self.hisparse_coordinator is None:
+            return True
+
+        requests = (
+            self.reqs
+            if selected_indices is None
+            else [self.reqs[i] for i in selected_indices]
+        )
+        host_required = self.hisparse_coordinator.host_tokens_required_next_decode(
+            requests,
+            speculative_token_budget=self._host_tokens_required_next_decode_spec(
+                requests
+            ),
+        )
+        return self.hisparse_coordinator.mem_pool_host.available_size() >= host_required
 
     def retract_all(self, server_args: ServerArgs):
         retracted_reqs = self.reqs

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2185,6 +2185,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             )
 
         retracted_reqs = []
+        reqs_to_abort: List[Req] = []
         first_iter = True
         while first_iter or (
             not self.check_decode_mem(selected_indices=sorted_indices)
@@ -2196,11 +2197,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             first_iter = False
             idx = sorted_indices.pop()
             req = self.reqs[idx]
-            retracted_reqs.append(req)
             # release memory and don't insert into the tree because we need the space instantly
-            self.release_req(idx, len(sorted_indices), server_args)
+            if self.release_req(idx, len(sorted_indices), server_args):
+                retracted_reqs.append(req)
+            else:
+                reqs_to_abort.append(req)
 
-        reqs_to_abort: List[Req] = []
         if len(sorted_indices) <= 1 and not self.check_decode_mem(
             selected_indices=sorted_indices
         ):
@@ -2235,13 +2237,30 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
         return retracted_reqs, new_estimate_ratio, reqs_to_abort
 
-    def release_req(self, idx: int, remaing_req_count: int, server_args: ServerArgs):
+    def release_req(
+        self, idx: int, remaing_req_count: int, server_args: ServerArgs
+    ) -> bool:
         req = self.reqs[idx]
+        should_retract = not isinstance(getattr(req, "to_finish", None), FINISH_ABORT)
 
         if self.hisparse_coordinator is not None and not req.finished():
-            self.hisparse_coordinator.retract_req(req)
+            if not should_retract:
+                self.hisparse_coordinator.request_finished(req)
+            else:
+                should_retract = self.hisparse_coordinator.retract_req(req)
+                if not should_retract:
+                    req.to_finish = FINISH_ABORT(
+                        "HiSparse preallocated host KV pool had no free slots while "
+                        "backing up the request for retract. Aborting this request "
+                        "instead of crashing the scheduler.",
+                        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    )
+                    self.hisparse_coordinator.request_finished(req)
 
-        if server_args.disaggregation_mode == "decode":
+        if (
+            server_args.disaggregation_mode == "decode"
+            and self.hisparse_coordinator is None
+        ):
             req.offload_kv_cache(
                 self.req_to_token_pool, self.token_to_kv_pool_allocator
             )
@@ -2251,7 +2270,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         num_tokens = remaing_req_count * envs.SGLANG_RETRACT_DECODE_STEPS.get()
         evict_from_tree_cache(self.tree_cache, num_tokens)
 
-        req.reset_for_retract()
+        if should_retract:
+            req.reset_for_retract()
+        return should_retract
 
     def prepare_encoder_info_decode(self):
         # Reset the encoder cached status

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3756,8 +3756,11 @@ class Scheduler(
                 remaining_retracted = []
                 for decode_req in self.disagg_decode_prealloc_queue.retracted_queue:
                     if recv_req.abort_all or decode_req.rid.startswith(recv_req.rid):
-                        assert hasattr(decode_req, "kv_cache_cpu")
-                        del decode_req.kv_cache_cpu
+                        if self.enable_hisparse:
+                            self.hisparse_coordinator.release_retracted_req(decode_req)
+                        else:
+                            assert hasattr(decode_req, "kv_cache_cpu")
+                            del decode_req.kv_cache_cpu
                         self.send_to_tokenizer.send_output(
                             AbortReq(rid=decode_req.rid), decode_req
                         )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -97,8 +97,8 @@ from sglang.srt.managers.io_struct import (
     ClearHiCacheReqInput,
     ClearHiCacheReqOutput,
     CloseSessionReqInput,
-    ContinueGenerationReqInput,
     ConfigureLoggingReq,
+    ContinueGenerationReqInput,
     DestroyWeightsUpdateGroupReqInput,
     DetachHiCacheStorageReqInput,
     DetachHiCacheStorageReqOutput,
@@ -2485,6 +2485,7 @@ class Scheduler(
         batch.output_ids = torch.tensor(
             [r.output_ids[-1] for r in reqs], dtype=torch.int64, device=device
         )
+        batch.input_ids = batch.output_ids
 
         if batch.return_logprob:
             batch.top_logprobs_nums = [r.top_logprobs_num for r in reqs]
@@ -2493,7 +2494,40 @@ class Scheduler(
         batch.sampling_info = SamplingBatchInfo.from_schedule_batch(
             batch, self.model_config.vocab_size
         )
-        # todo hisparse, maybe other info to contain for the new batch
+
+        if not batch.spec_algorithm.is_none():
+            missing_spec_info_rids = [
+                req.rid
+                for req in reqs
+                if getattr(req, "hisparse_spec_info", None) is None
+            ]
+            if missing_spec_info_rids:
+                raise RuntimeError(
+                    "HiSparse decode batch is missing speculative draft state for requests: "
+                    + ", ".join(missing_spec_info_rids)
+                )
+
+            batch.spec_info = reqs[0].hisparse_spec_info
+            reqs[0].hisparse_spec_info = None
+            for req in reqs[1:]:
+                batch.spec_info.merge_batch(req.hisparse_spec_info)
+                req.hisparse_spec_info = None
+
+            if batch.is_spec_v2:
+                if batch.spec_info.new_seq_lens is None:
+                    raise RuntimeError(
+                        "HiSparse spec-v2 decode batch is missing new_seq_lens for draft state rebuild."
+                    )
+                future_indices = self.future_map.alloc_future_indices(len(reqs))
+                self.future_map.store_to_map_for_new_batch(
+                    future_indices, batch.spec_info
+                )
+                batch.spec_info.future_indices = future_indices
+                batch.spec_info.verify_done = None
+                batch.seq_lens = batch.spec_info.new_seq_lens
+                batch.seq_lens_cpu = batch.seq_lens.cpu()
+                batch.orig_seq_lens = batch.seq_lens.to(dtype=torch.int32)
+                batch.seq_lens_sum = batch.seq_lens_cpu.sum().item()
         return batch
 
     def get_next_batch_to_run(self) -> Optional[ScheduleBatch]:
@@ -3087,6 +3121,12 @@ class Scheduler(
                 )
                 future_indices_or_next_token_ids = batch_result.next_token_ids
                 self.update_cache_from_scheduler(batch, batch_result)
+                if (
+                    self.enable_hisparse
+                    and batch.is_spec_v2
+                    and batch_result.next_draft_input is not None
+                ):
+                    batch.spec_info = batch_result.next_draft_input
 
             # NOTE: future_indices_or_next_token_ids is used in ScheduleBatch,
             #       which can probably be replaced by future_indices later [TODO(lsyin)].
@@ -3328,6 +3368,7 @@ class Scheduler(
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 idle &= len(self.disagg_prefill_inflight_queue) == 0
                 idle &= len(self.disagg_prefill_bootstrap_queue.queue) == 0
+                idle &= len(self.disagg_prefill_bootstrap_queue.pending_queue) == 0
 
             if self.disaggregation_mode == DisaggregationMode.DECODE:
                 idle &= len(self.disagg_decode_prealloc_queue.queue) == 0
@@ -3606,32 +3647,109 @@ class Scheduler(
 
         # Delete requests not in the waiting queue when PD disaggregation is enabled
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            # Abort requests that are queued before KV sender admission.
+            remaining_pending = deque()
+            for req in self.disagg_prefill_bootstrap_queue.pending_queue:
+                if recv_req.abort_all or req.rid.startswith(recv_req.rid):
+                    logger.debug(f"Abort pending bootstrap request. {req.rid=}")
+                    if self.enable_hicache_storage:
+                        self.tree_cache.release_aborted_request(req.rid)
+                    self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+                else:
+                    remaining_pending.append(req)
+            self.disagg_prefill_bootstrap_queue.pending_queue = remaining_pending
+
             # Abort requests that have not yet been bootstrapped
+            remaining_bootstrap = []
             for req in self.disagg_prefill_bootstrap_queue.queue:
                 if recv_req.abort_all or req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort bootstrap queue request. {req.rid=}")
                     if hasattr(req.disagg_kv_sender, "abort"):
                         req.disagg_kv_sender.abort()
+                    if hasattr(req.disagg_kv_sender, "clear"):
+                        req.disagg_kv_sender.clear()
+                    if self.enable_hicache_storage:
+                        self.tree_cache.release_aborted_request(req.rid)
+                    self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+                else:
+                    remaining_bootstrap.append(req)
+            self.disagg_prefill_bootstrap_queue.queue = remaining_bootstrap
 
             # Abort in-flight requests
+            remaining_inflight = []
             for req in self.disagg_prefill_inflight_queue:
                 if recv_req.abort_all or req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort inflight queue request. {req.rid=}")
                     if hasattr(req.disagg_kv_sender, "abort"):
                         req.disagg_kv_sender.abort()
+                    if hasattr(req.disagg_kv_sender, "clear"):
+                        req.disagg_kv_sender.clear()
+                    release_kv_cache(req, self.tree_cache, is_insert=False)
+                    release_req_to_metadata_buffer(
+                        req, self.req_to_metadata_buffer_idx_allocator
+                    )
+                    self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+                else:
+                    remaining_inflight.append(req)
+            self.disagg_prefill_inflight_queue = remaining_inflight
 
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
             # Abort requests that have not yet finished preallocation
+            aborted_prealloc_rids = set()
+            remaining_prealloc = []
             for decode_req in self.disagg_decode_prealloc_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort prealloc queue request. {decode_req.req.rid=}")
                     decode_req.kv_receiver.abort()
+                    if hasattr(decode_req.kv_receiver, "clear"):
+                        decode_req.kv_receiver.clear()
+                    aborted_prealloc_rids.add(decode_req.req.rid)
+                    self.send_to_tokenizer.send_output(
+                        AbortReq(rid=decode_req.req.rid), decode_req.req
+                    )
+                else:
+                    remaining_prealloc.append(decode_req)
+            self.disagg_decode_prealloc_queue.queue = remaining_prealloc
+            if aborted_prealloc_rids:
+                self.disagg_decode_prealloc_queue.pending_reqs = [
+                    decode_req
+                    for decode_req in self.disagg_decode_prealloc_queue.pending_reqs
+                    if decode_req.req.rid not in aborted_prealloc_rids
+                ]
 
             # Abort requests waiting for kvcache to release tree cache
+            transfer_queue = self.disagg_decode_transfer_queue
+            remaining_transfer = []
             for decode_req in self.disagg_decode_transfer_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
                     decode_req.kv_receiver.abort()
+                    if (
+                        transfer_queue.enable_staging
+                        and transfer_queue.staging_handler is not None
+                        and transfer_queue.staging_handler.is_staging_room(
+                            decode_req.req.bootstrap_room
+                        )
+                    ):
+                        transfer_queue.staging_handler.unregister_decode_req(
+                            decode_req.req.bootstrap_room
+                        )
+                    if decode_req.metadata_buffer_index != -1:
+                        transfer_queue.req_to_metadata_buffer_idx_allocator.free(
+                            decode_req.metadata_buffer_index
+                        )
+                        decode_req.metadata_buffer_index = -1
+                    if hasattr(decode_req.kv_receiver, "clear"):
+                        decode_req.kv_receiver.clear()
+                    if self.enable_hisparse:
+                        self.hisparse_coordinator.request_finished(decode_req.req)
+                    release_kv_cache(decode_req.req, self.tree_cache, is_insert=False)
+                    self.send_to_tokenizer.send_output(
+                        AbortReq(rid=decode_req.req.rid), decode_req.req
+                    )
+                else:
+                    remaining_transfer.append(decode_req)
+            self.disagg_decode_transfer_queue.queue = remaining_transfer
 
             # Abort requests already retracted to CPU cache
             if self.disagg_decode_prealloc_queue.retracted_queue:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2376,6 +2376,10 @@ class Scheduler(
                     ),
                     req,
                 )
+                if self.disaggregation_mode == DisaggregationMode.DECODE:
+                    if self.enable_hisparse:
+                        self.hisparse_coordinator.request_finished(req)
+                    release_kv_cache(req, self.tree_cache, is_insert=False)
                 deleted_reqs.add(req)
 
         if deleted_reqs:
@@ -3605,7 +3609,6 @@ class Scheduler(
         return RpcReqOutput(success, "" if not exec else str(exec))
 
     def abort_request(self, recv_req: AbortReq):
-        # todo hisparse, release resources for abort requests in hisparse coordinator
         # Delete requests in the waiting queue
         to_del = []
         for i, req in enumerate(self.waiting_queue):
@@ -3624,6 +3627,8 @@ class Scheduler(
             self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
             # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
             if self.disaggregation_mode == DisaggregationMode.DECODE:
+                if self.enable_hisparse:
+                    self.hisparse_coordinator.request_finished(req)
                 release_kv_cache(req, self.tree_cache)
             # For disaggregation prefill mode, free the metadata buffer index
             if self.disaggregation_mode == DisaggregationMode.PREFILL:

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -182,6 +182,17 @@ class SchedulerOutputProcessorMixin:
                     elem = elem.copy()
                 req.customized_info[k].append(elem)
 
+    def _stash_hisparse_spec_info(
+        self: Scheduler, batch: ScheduleBatch, batch_index: int, req: Req
+    ) -> None:
+        if not self.enable_hisparse or batch.spec_info is None:
+            return
+        if not hasattr(batch.spec_info, "slice_single"):
+            raise RuntimeError(
+                f"HiSparse cannot stash speculative state for {type(batch.spec_info).__name__}"
+            )
+        req.hisparse_spec_info = batch.spec_info.slice_single(batch_index)
+
     def process_batch_result_prefill(
         self: Scheduler,
         batch: ScheduleBatch,
@@ -210,6 +221,12 @@ class SchedulerOutputProcessorMixin:
                 result.extend_input_len_per_req,
                 result.extend_logprob_start_len_per_req,
             )
+            if (
+                self.enable_hisparse
+                and batch.spec_info is None
+                and result.next_draft_input is not None
+            ):
+                batch.spec_info = result.next_draft_input
 
             # Move next_token_ids and logprobs to cpu
             next_token_ids = next_token_ids.tolist()
@@ -262,6 +279,7 @@ class SchedulerOutputProcessorMixin:
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                         maybe_cache_unfinished_req(req, self.tree_cache)
                         if self.enable_hisparse:
+                            self._stash_hisparse_spec_info(batch, i, req)
                             self.hisparse_coordinator.admit_request_into_staging(req)
 
                     self.maybe_collect_customized_info(i, req, logits_output)

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -674,6 +674,8 @@ class SchedulerOutputProcessorMixin:
                 if not self.decode_offload_manager.offload_kv_cache(req):
                     self.decode_offload_manager.finalize_release_on_finish(req)
             elif req.req_pool_idx is None:
+                if getattr(req, "mamba_pool_idx", None) is not None:
+                    release_kv_cache(req, self.tree_cache)
                 logger.warning(
                     "Skip KV release for finished req %s because req_pool_idx is "
                     "already None (kv_committed_freed=%s, kv_overallocated_freed=%s)",

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -673,6 +673,14 @@ class SchedulerOutputProcessorMixin:
                 # Asynchronously offload KV cache; release_kv_cache will be called after Device->Host transfer completes
                 if not self.decode_offload_manager.offload_kv_cache(req):
                     self.decode_offload_manager.finalize_release_on_finish(req)
+            elif req.req_pool_idx is None:
+                logger.warning(
+                    "Skip KV release for finished req %s because req_pool_idx is "
+                    "already None (kv_committed_freed=%s, kv_overallocated_freed=%s)",
+                    req.rid,
+                    req.kv_committed_freed,
+                    req.kv_overallocated_freed,
+                )
             else:
                 if self.enable_hisparse:
                     self.hisparse_coordinator.request_finished(req)

--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -2,7 +2,7 @@
 
 import logging
 import weakref
-from typing import Optional
+from typing import Optional, Tuple
 
 import psutil
 import torch
@@ -34,6 +34,27 @@ else:
             "HiSparse device KV transfer requires sgl_kernel.kvcacheio (CUDA/ROCm). "
             "It is not available on this backend."
         )
+
+
+def _hisparse_backup_state(
+    logical_allocator, hisparse_allocator, mapping: torch.Tensor
+) -> Tuple:
+    return (
+        logical_allocator.backup_state(),
+        hisparse_allocator.backup_state(),
+        mapping.clone(),
+    )
+
+
+def _hisparse_restore_state(
+    logical_allocator, hisparse_allocator, mapping: torch.Tensor, state: Tuple
+) -> None:
+    logical_state, hisparse_state, mapping_snapshot = state
+    logical_allocator.restore_state(logical_state)
+    hisparse_allocator.restore_state(hisparse_state)
+    mapping[: mapping_snapshot.shape[0]].copy_(mapping_snapshot)
+    if mapping_snapshot.shape[0] < mapping.shape[0]:
+        mapping[mapping_snapshot.shape[0] :] = 0
 
 
 class HiSparseNSATokenToKVPool(NSATokenToKVPool):
@@ -286,6 +307,51 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def get_last_loc_hisparse_device(self, last_locs: torch.Tensor):
         return self._kvcache._translate_loc_to_hisparse_device(last_locs)
 
+    def alloc_extend_with_device_mapping(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        device_slots: torch.Tensor,
+        backup_state: bool = False,
+    ):
+        """Allocate logical indices and map them to caller-managed HiSparse slots."""
+        avail = self.logical_attn_allocator.available_size()
+        if avail < extend_num_tokens:
+            raise RuntimeError(
+                f"HiSparse logical alloc: need {extend_num_tokens} tokens but only "
+                f"{avail} are available."
+            )
+
+        logical_state = (
+            self.logical_attn_allocator.backup_state() if backup_state else None
+        )
+        out = self.logical_attn_allocator.alloc_extend(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+        )
+        if out is None:
+            raise RuntimeError(
+                f"HiSparse logical alloc failed for {extend_num_tokens} tokens. "
+                f"Logical pool available: {self.logical_attn_allocator.available_size()}"
+            )
+
+        self.full_to_hisparse_device_index_mapping[out] = device_slots
+        if backup_state:
+            return out, (logical_state, out.clone())
+        return out
+
+    def clear_device_mapping(self, logical_indices: torch.Tensor):
+        """Clear mappings for caller-managed slots before freeing logical indices."""
+        self.full_to_hisparse_device_index_mapping[logical_indices] = 0
+
     def alloc_extend(
         self,
         prefix_lens: torch.Tensor,
@@ -384,9 +450,28 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             <= self.hisparse_attn_allocator.size
         )
 
+    def backup_state(self):
+        return _hisparse_backup_state(
+            self.logical_attn_allocator,
+            self.hisparse_attn_allocator,
+            self.full_to_hisparse_device_index_mapping,
+        )
+
+    def restore_state(self, state):
+        if len(state) == 2:
+            # Draft extra-page mappings must stay live until accepted tokens are finalized.
+            self.logical_attn_allocator.restore_state(state[0])
+            return
+
+        _hisparse_restore_state(
+            self.logical_attn_allocator,
+            self.hisparse_attn_allocator,
+            self.full_to_hisparse_device_index_mapping,
+            state,
+        )
+
 
 class DeepSeekV4SingleKVPoolHost:
-
     def __init__(
         self,
         device_pool: HiSparseC4DevicePool,
@@ -395,7 +480,6 @@ class DeepSeekV4SingleKVPoolHost:
         pin_memory: bool = True,
         device: str = "cpu",
     ):
-
         assert host_size > 0, "Host size must be specified and greater than 0"
         assert page_size == 1, "Host page size must be 1 for DeepSeekV4SingleKVPoolHost"
 
@@ -501,7 +585,6 @@ class DeepSeekV4SingleKVPoolHost:
 
 
 class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
-
     def __init__(
         self,
         logical_attn_allocator: BaseTokenToKVPoolAllocator,
@@ -775,4 +858,19 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert (
             self.hisparse_attn_allocator.available_size()
             <= self.hisparse_attn_allocator.size
+        )
+
+    def backup_state(self):
+        return _hisparse_backup_state(
+            self.logical_attn_allocator,
+            self.hisparse_attn_allocator,
+            self.full_to_hisparse_device_index_mapping,
+        )
+
+    def restore_state(self, state):
+        _hisparse_restore_state(
+            self.logical_attn_allocator,
+            self.hisparse_attn_allocator,
+            self.full_to_hisparse_device_index_mapping,
+            state,
         )

--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -319,11 +319,21 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         backup_state: bool = False,
     ):
         """Allocate logical indices and map them to caller-managed HiSparse slots."""
-        avail = self.logical_attn_allocator.available_size()
-        if avail < extend_num_tokens:
+        num_new_pages = get_num_new_pages(
+            seq_lens=seq_lens_cpu,
+            page_size=self.page_size,
+            prefix_lens=prefix_lens_cpu,
+        )
+        if self.logical_attn_allocator.need_sort and num_new_pages > len(
+            self.logical_attn_allocator.free_pages
+        ):
+            self.logical_attn_allocator.merge_and_sort_free()
+        avail_pages = len(self.logical_attn_allocator.free_pages)
+        if num_new_pages > avail_pages:
             raise RuntimeError(
-                f"HiSparse logical alloc: need {extend_num_tokens} tokens but only "
-                f"{avail} are available."
+                f"HiSparse logical alloc: need {num_new_pages} new pages for "
+                f"{extend_num_tokens} tokens but only {avail_pages} pages are "
+                "available."
             )
 
         logical_state = (

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -179,13 +179,13 @@ class ReqToTokenPool:
         offset = 0
         for r in reqs:
             if r.req_pool_idx is None:
-                r.req_pool_idx = select_index[offset]
+                r.req_pool_idx = int(select_index[offset])
                 offset += 1
-        return [r.req_pool_idx for r in reqs]
+        return [int(r.req_pool_idx) for r in reqs]
 
     def free(self, req: Req):
         assert req.req_pool_idx is not None, "request must have req_pool_idx"
-        self.free_slots.append(req.req_pool_idx)
+        self.free_slots.append(int(req.req_pool_idx))
         req.req_pool_idx = None
 
     def clear(self):

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -489,6 +489,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             dimensions=batch.dimensions,
             return_hidden_states_before_norm=batch.return_hidden_states_before_norm,
             return_pooled_hidden_states=batch.return_pooled_hidden_states,
+            hisparse_coordinator=batch.hisparse_coordinator,
             rids=[req.rid for req in batch.reqs],
         )
         device = model_runner.device

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3240,6 +3240,20 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         reinit_attn_backend: bool = False,
         split_forward_count: int = 1,
     ) -> ModelRunnerOutput:
+        active_hisparse_coordinator = self.hisparse_coordinator
+        if (
+            active_hisparse_coordinator is None
+            and forward_batch.hisparse_coordinator is not None
+            and callable(
+                getattr(
+                    forward_batch.token_to_kv_pool,
+                    "translate_loc_to_hisparse_device",
+                    None,
+                )
+            )
+        ):
+            active_hisparse_coordinator = forward_batch.hisparse_coordinator
+
         # Check whether can run cuda graph
         mode_check = (
             forward_batch.forward_mode.is_cpu_graph
@@ -3255,11 +3269,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Hisparse coordinator
         if (
             forward_batch.forward_mode.is_decode()
-            and self.hisparse_coordinator is not None
+            and active_hisparse_coordinator is not None
         ):
-            forward_batch.hisparse_coordinator = self.hisparse_coordinator
-            self.hisparse_coordinator.wait_for_pending_backup()
-            self.hisparse_coordinator.num_real_reqs.fill_(forward_batch.batch_size)
+            forward_batch.hisparse_coordinator = active_hisparse_coordinator
+            active_hisparse_coordinator.wait_for_pending_backup()
+            active_hisparse_coordinator.num_real_reqs.fill_(forward_batch.batch_size)
 
         # Replay cuda graph if applicable
         if can_run_graph:
@@ -3292,9 +3306,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.token_to_kv_pool.set_swa_loc(forward_batch.out_cache_loc_swa)
 
         # Hisparse coordinator
-        forward_batch.hisparse_coordinator = self.hisparse_coordinator
-        if self.hisparse_coordinator is not None:
-            self.hisparse_coordinator.num_real_reqs.fill_(forward_batch.batch_size)
+        forward_batch.hisparse_coordinator = active_hisparse_coordinator
+        if active_hisparse_coordinator is not None:
+            active_hisparse_coordinator.num_real_reqs.fill_(forward_batch.batch_size)
 
         # Forward without cuda graph
         if forward_batch.forward_mode.is_decode():

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -757,14 +757,24 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.init_cublas()
             self.init_attention_backend()
             self.kernel_warmup()
-            # Init hisparse coordinator (must happen before CUDA graph capture)
-            if self.enable_hisparse:
+            # Init hisparse coordinator (must happen before CUDA graph capture).
+            # Only the target runner owns scheduler-populated staging state.
+            if self.enable_hisparse and not self.is_draft_worker:
                 from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
                 from sglang.srt.mem_cache.sparsity import parse_hisparse_config
 
                 hisparse_cfg = parse_hisparse_config(self.server_args)
                 hisparse_top_k = getattr(
                     self.model_config.hf_text_config, "index_topk", hisparse_cfg.top_k
+                )
+                hisparse_host_allocator_type = (
+                    "mooncake"
+                    if (
+                        self.server_args.disaggregation_mode == "decode"
+                        and self.server_args.disaggregation_transfer_backend
+                        == "mooncake"
+                    )
+                    else "default"
                 )
                 self.hisparse_coordinator = HiSparseCoordinator(
                     req_to_token_pool=self.req_to_token_pool,
@@ -778,6 +788,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                         else self.tp_group.cpu_group
                     ),
                     host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
+                    host_allocator_type=hisparse_host_allocator_type,
                 )
             self._pre_initialize_flashinfer_allreduce_workspace()
             self.init_device_graphs()

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -766,6 +766,18 @@ class ModelRunnerKVCacheMixin:
                 self.token_to_kv_pool.full_to_swa_index_mapping = (
                     swa_allocator.full_to_swa_index_mapping
                 )
+            if self.enable_hisparse:
+                if isinstance(
+                    self.token_to_kv_pool_allocator, HiSparseTokenToKVPoolAllocator
+                ):
+                    self.token_to_kv_pool.full_to_hisparse_device_index_mapping = (
+                        self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+                    )
+                else:
+                    assert isinstance(
+                        self.token_to_kv_pool_allocator,
+                        DeepSeekV4HiSparseTokenToKVPoolAllocator,
+                    )
 
         # Defensive check: the explicit validation above should reject known
         # unsupported pool families before allocation. Keep this guard here so

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -1004,6 +1004,7 @@ class SchedulerMetricsMixin:
 
         waiting_queues = [self.waiting_queue]
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            waiting_queues.append(self.disagg_prefill_bootstrap_queue.pending_queue)
             waiting_queues.append(self.disagg_prefill_bootstrap_queue.queue)
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
             waiting_queues.append(self.disagg_decode_prealloc_queue.queue)
@@ -1055,6 +1056,7 @@ class SchedulerMetricsMixin:
         disaggregation = None
         if include_all or "disagg" in include:
             mode_str = "null"
+            prefill_pending = 0
             prefill_bootstrap = 0
             prefill_inflight = 0
             decode_prealloc = 0
@@ -1063,6 +1065,7 @@ class SchedulerMetricsMixin:
 
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 mode_str = "prefill"
+                prefill_pending = len(self.disagg_prefill_bootstrap_queue.pending_queue)
                 prefill_bootstrap = len(self.disagg_prefill_bootstrap_queue.queue)
                 prefill_inflight = len(self.disagg_prefill_inflight_queue)
             elif self.disaggregation_mode == DisaggregationMode.DECODE:
@@ -1075,6 +1078,7 @@ class SchedulerMetricsMixin:
 
             disaggregation = DisaggregationMetrics(
                 mode=mode_str,
+                prefill_pending_queue_reqs=prefill_pending,
                 prefill_bootstrap_queue_reqs=prefill_bootstrap,
                 prefill_inflight_queue_reqs=prefill_inflight,
                 decode_prealloc_queue_reqs=decode_prealloc,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6949,6 +6949,33 @@ class ServerArgs:
 
         validate_hisparse(self)
 
+        if self.enable_hisparse and self.speculative_algorithm is not None:
+            from sglang.srt.configs.model_config import is_deepseek_nsa
+
+            if is_deepseek_nsa(self.get_model_config().hf_config):
+                from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+
+                hisparse_cfg = parse_hisparse_config(self)
+                hisparse_page_size = getattr(hisparse_cfg, "page_size", None)
+                if hisparse_page_size is None:
+                    hisparse_page_size = 64
+                max_draft = self.speculative_num_draft_tokens or 0
+                if max_draft >= hisparse_page_size:
+                    raise ValueError(
+                        f"hiSparse extra page capacity ({hisparse_page_size - 1} slots) "
+                        f"is insufficient for speculative_num_draft_tokens={max_draft}. "
+                        f"Reduce draft tokens or increase hiSparse page_size."
+                    )
+                if (
+                    self.speculative_eagle_topk is not None
+                    and self.speculative_eagle_topk > 1
+                    and self.page_size > 1
+                ):
+                    raise ValueError(
+                        "HiSparse + speculative topk > 1 + page_size > 1 is not yet "
+                        "supported. Use speculative_eagle_topk=1 or page_size=1."
+                    )
+
         assert (
             self.schedule_conservativeness >= 0
         ), "schedule_conservativeness must be non-negative"

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -189,6 +189,26 @@ class EAGLEDraftCudaGraphRunner:
     def _cache_loc_dtype(self):
         return torch.int64
 
+    def _attach_hisparse_coordinator(
+        self, forward_batch: ForwardBatch, num_real_reqs: int
+    ) -> None:
+        target_worker = getattr(self.eagle_worker, "target_worker", None)
+        target_model_runner = getattr(target_worker, "model_runner", None)
+        coordinator = getattr(target_model_runner, "hisparse_coordinator", None)
+        if coordinator is None:
+            return
+        if not callable(
+            getattr(
+                forward_batch.token_to_kv_pool,
+                "translate_loc_to_hisparse_device",
+                None,
+            )
+        ):
+            return
+        forward_batch.hisparse_coordinator = coordinator
+        coordinator.wait_for_pending_backup()
+        coordinator.num_real_reqs.fill_(num_real_reqs)
+
     def can_run(self, forward_batch: ForwardBatch):
         if self.require_mlp_tp_gather:
             cuda_graph_bs = (
@@ -351,6 +371,7 @@ class EAGLEDraftCudaGraphRunner:
         )
 
         # Attention backend
+        self._attach_hisparse_coordinator(forward_batch, num_seqs)
         self.draft_attn_backend.init_forward_metadata_capture_cuda_graph(forward_batch)
 
         # Run and capture
@@ -469,6 +490,7 @@ class EAGLEDraftCudaGraphRunner:
             buffers.seq_lens_cpu[:raw_bs].copy_(forward_batch.seq_lens_cpu)
             forward_batch.seq_lens_cpu = buffers.seq_lens_cpu[:bs]
 
+        self._attach_hisparse_coordinator(forward_batch, raw_bs)
         self.draft_attn_backend.init_forward_metadata_replay_cuda_graph(
             forward_batch, bs
         )

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -226,6 +226,12 @@ class EAGLEDraftExtendCudaGraphRunner:
             )
 
     def can_run(self, forward_batch: ForwardBatch):
+        if self._uses_target_hisparse_coordinator(forward_batch):
+            # HiSparse draft-extend uses per-request variable accepted-token
+            # counts. The captured graph has a fixed full-row layout, so replay
+            # can reinterpret packed rows incorrectly after verify.
+            return False
+
         if self.require_mlp_tp_gather:
             cuda_graph_bs = (
                 max(forward_batch.global_num_tokens_cpu) // self.num_tokens_per_bs
@@ -252,6 +258,40 @@ class EAGLEDraftExtendCudaGraphRunner:
 
     def _cache_loc_dtype(self):
         return torch.int64
+
+    def _uses_target_hisparse_coordinator(self, forward_batch: ForwardBatch) -> bool:
+        target_worker = getattr(self.eagle_worker, "target_worker", None)
+        target_model_runner = getattr(target_worker, "model_runner", None)
+        coordinator = getattr(target_model_runner, "hisparse_coordinator", None)
+        if coordinator is None:
+            return False
+        return callable(
+            getattr(
+                forward_batch.token_to_kv_pool,
+                "translate_loc_to_hisparse_device",
+                None,
+            )
+        )
+
+    def _attach_hisparse_coordinator(
+        self, forward_batch: ForwardBatch, num_real_reqs: int
+    ) -> None:
+        target_worker = getattr(self.eagle_worker, "target_worker", None)
+        target_model_runner = getattr(target_worker, "model_runner", None)
+        coordinator = getattr(target_model_runner, "hisparse_coordinator", None)
+        if coordinator is None:
+            return
+        if not callable(
+            getattr(
+                forward_batch.token_to_kv_pool,
+                "translate_loc_to_hisparse_device",
+                None,
+            )
+        ):
+            return
+        forward_batch.hisparse_coordinator = coordinator
+        coordinator.wait_for_pending_backup()
+        coordinator.num_real_reqs.fill_(num_real_reqs)
 
     def _capture_init(self, run_once_fn):
         for _ in range(2):
@@ -383,6 +423,7 @@ class EAGLEDraftExtendCudaGraphRunner:
             padded_static_len=self.padded_static_len,
         )
 
+        self._attach_hisparse_coordinator(forward_batch, bs)
         self.draft_extend_attn_backend.init_forward_metadata_capture_cuda_graph(
             bs=bs,
             num_tokens=num_tokens,
@@ -519,6 +560,7 @@ class EAGLEDraftExtendCudaGraphRunner:
             forward_batch.spec_info.num_correct_drafts = buffers.num_correct_drafts[:bs]
             forward_batch.spec_info.num_accept_tokens = buffers.num_accept_tokens[:bs]
 
+        self._attach_hisparse_coordinator(forward_batch, raw_bs)
         self.draft_extend_attn_backend.init_forward_metadata_replay_cuda_graph(
             bs=bs,
             req_pool_indices=buffers.req_pool_indices,

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -22,6 +22,7 @@ from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_token_slots,
+    evict_from_tree_cache,
     get_last_loc,
 )
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
@@ -68,6 +69,18 @@ def _draft_runner_of(worker):
     )
 
 
+def _slice_optional_tensor(tensor: Optional[torch.Tensor], sli: slice):
+    return None if tensor is None else tensor[sli]
+
+
+def _cat_optional_tensor(left: Optional[torch.Tensor], right: Optional[torch.Tensor]):
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return torch.cat([left, right], axis=0)
+
+
 @dataclass
 class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
     draft_token: torch.Tensor
@@ -96,6 +109,74 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
     def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
         return self.draft_token_num, self.draft_token_num
 
+    def slice_single(self, batch_index: int) -> "EagleVerifyInput":
+        sli = slice(batch_index, batch_index + 1)
+        token_sli = slice(
+            batch_index * self.draft_token_num,
+            (batch_index + 1) * self.draft_token_num,
+        )
+        if self.custom_mask is not None and self.seq_lens_cpu is not None:
+            mask_start = (
+                int(
+                    (
+                        self.seq_lens_cpu[:batch_index].sum()
+                        + batch_index * self.draft_token_num
+                    ).item()
+                )
+                * self.draft_token_num
+            )
+            mask_len = (
+                int(self.seq_lens_cpu[batch_index].item()) + self.draft_token_num
+            ) * self.draft_token_num
+            custom_mask = self.custom_mask[mask_start : mask_start + mask_len]
+        else:
+            custom_mask = self.custom_mask
+        return EagleVerifyInput(
+            draft_token=self.draft_token[token_sli],
+            custom_mask=custom_mask,
+            positions=self.positions[token_sli],
+            retrieve_index=self.retrieve_index[sli],
+            retrieve_next_token=self.retrieve_next_token[sli],
+            retrieve_next_sibling=self.retrieve_next_sibling[sli],
+            retrieve_cum_len=_slice_optional_tensor(self.retrieve_cum_len, sli),
+            topk=self.topk,
+            draft_token_num=self.draft_token_num,
+            spec_steps=self.spec_steps,
+            capture_hidden_mode=self.capture_hidden_mode,
+            seq_lens_sum=(
+                int(self.seq_lens_cpu[batch_index].item())
+                if self.seq_lens_cpu is not None
+                else None
+            ),
+            seq_lens_cpu=_slice_optional_tensor(self.seq_lens_cpu, sli),
+            grammar=self.grammar,
+            num_tokens_per_req=self.num_tokens_per_req,
+        )
+
+    def merge_batch(self, spec_info: "EagleVerifyInput"):
+        self.draft_token = torch.cat([self.draft_token, spec_info.draft_token], axis=0)
+        self.custom_mask = _cat_optional_tensor(self.custom_mask, spec_info.custom_mask)
+        self.positions = torch.cat([self.positions, spec_info.positions], axis=0)
+        self.retrieve_index = torch.cat(
+            [self.retrieve_index, spec_info.retrieve_index], axis=0
+        )
+        self.retrieve_next_token = torch.cat(
+            [self.retrieve_next_token, spec_info.retrieve_next_token], axis=0
+        )
+        self.retrieve_next_sibling = torch.cat(
+            [self.retrieve_next_sibling, spec_info.retrieve_next_sibling], axis=0
+        )
+        self.retrieve_cum_len = _cat_optional_tensor(
+            self.retrieve_cum_len, spec_info.retrieve_cum_len
+        )
+        self.seq_lens_cpu = _cat_optional_tensor(
+            self.seq_lens_cpu, spec_info.seq_lens_cpu
+        )
+        if self.seq_lens_sum is None:
+            self.seq_lens_sum = spec_info.seq_lens_sum
+        elif spec_info.seq_lens_sum is not None:
+            self.seq_lens_sum += spec_info.seq_lens_sum
+
     @classmethod
     def create_idle_input(cls, topk: int, spec_steps: int, num_verify_tokens: int):
         return cls(
@@ -121,7 +202,6 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         )
 
     def prepare_for_verify(self, batch: ScheduleBatch, page_size: int):
-
         if batch.forward_mode.is_idle():
             return
 
@@ -143,15 +223,41 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 batch.req_pool_indices,
                 prefix_lens,
             )
-            batch.out_cache_loc = alloc_paged_token_slots_extend(
-                batch.tree_cache,
-                prefix_lens,
-                prefix_lens_cpu,
-                end_offset,
-                end_offset_cpu,
-                last_loc,
-                len(batch.input_ids),
-            )
+            hisparse_coordinator = batch.hisparse_coordinator
+            if (
+                hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                allocator = batch.tree_cache.token_to_kv_pool_allocator
+                evict_from_tree_cache(
+                    batch.tree_cache,
+                    len(batch.input_ids) + len(prefix_lens_cpu) * allocator.page_size,
+                )
+                device_slots = hisparse_coordinator.get_draft_device_slots(
+                    batch.req_pool_indices,
+                    self.draft_token_num,
+                    prefix_lens_cpu,
+                )
+                batch.out_cache_loc = allocator.alloc_extend_with_device_mapping(
+                    prefix_lens,
+                    prefix_lens_cpu,
+                    end_offset,
+                    end_offset_cpu,
+                    last_loc,
+                    len(batch.input_ids),
+                    device_slots,
+                )
+            else:
+                batch.out_cache_loc = alloc_paged_token_slots_extend(
+                    batch.tree_cache,
+                    prefix_lens,
+                    prefix_lens_cpu,
+                    end_offset,
+                    end_offset_cpu,
+                    last_loc,
+                    len(batch.input_ids),
+                )
+            self.last_loc = last_loc
 
         bs = batch.batch_size()
         assign_req_to_token_pool_func(
@@ -443,9 +549,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     try:
                         req.grammar.accept_token(id)
                     except ValueError as e:
-                        logger.info(
-                            f"{i=}, {req=}\n" f"{accept_index=}\n" f"{predict=}\n"
-                        )
+                        logger.info(f"{i=}, {req=}\n{accept_index=}\n{predict=}\n")
                         raise e
                     req.check_finished()
                 if req.finished():
@@ -484,6 +588,34 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         # try to unify the tensor representation and list representation
         num_correct_drafts_list = num_correct_drafts_cpu.tolist()
         num_accept_tokens_list = num_accept_tokens_cpu.tolist()
+
+        hisparse_coordinator = batch.hisparse_coordinator
+        if (
+            hisparse_coordinator is not None
+            and hisparse_coordinator.supports_hisparse_draft_slots()
+        ):
+            counts = num_correct_drafts.to(torch.int64) + 1
+            offsets = torch.cat(
+                [
+                    torch.zeros(1, dtype=torch.int64, device=counts.device),
+                    counts.cumsum(0),
+                ]
+            )
+            pos_in_segment = torch.arange(
+                accept_index.numel(), dtype=torch.int64, device=counts.device
+            ) - torch.repeat_interleave(offsets[:-1], counts)
+            accepted_token_positions = (
+                torch.repeat_interleave(batch.seq_lens.to(torch.int64), counts)
+                + pos_in_segment
+            )
+            hisparse_coordinator.finalize_accepted_tokens(
+                batch.req_pool_indices,
+                batch.out_cache_loc[accept_index],
+                batch.out_cache_loc,
+                num_correct_drafts,
+                num_correct_drafts_cpu,
+                accepted_token_positions,
+            )
 
         if page_size == 1:
             # TODO: boolean array index leads to a device sync. Remove it.
@@ -540,6 +672,14 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 token_to_kv_pool_allocator.free(to_free_slots)
 
                 # Copy the kv cache
+                if (
+                    hisparse_coordinator is not None
+                    and hisparse_coordinator.supports_hisparse_draft_slots()
+                ):
+                    raise NotImplementedError(
+                        "HiSparse + speculative topk > 1 + page_size > 1 needs "
+                        "hisparse-aware move_kv_cache translation."
+                    )
                 batch.token_to_kv_pool_allocator.get_kvcache().move_kv_cache(
                     tgt_cache_loc, src_cache_loc
                 )
@@ -709,7 +849,6 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
         return self.num_tokens_per_req, self.num_tokens_for_logprob_per_req
 
     def prepare_for_extend(self, batch: ScheduleBatch):
-
         if batch.forward_mode.is_idle():
             return
 
@@ -790,6 +929,24 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             if self.hidden_states is not None:
                 self.hidden_states = self.hidden_states[new_indices]
             self.bonus_tokens = self.bonus_tokens[new_indices]
+
+    def slice_single(self, batch_index: int) -> "EagleDraftInput":
+        sli = slice(batch_index, batch_index + 1)
+        future_indices = None
+        if self.future_indices is not None:
+            future_indices = FutureIndices(indices=self.future_indices.indices[sli])
+        return EagleDraftInput(
+            topk_p=_slice_optional_tensor(self.topk_p, sli),
+            topk_index=_slice_optional_tensor(self.topk_index, sli),
+            hidden_states=_slice_optional_tensor(self.hidden_states, sli),
+            capture_hidden_mode=self.capture_hidden_mode,
+            bonus_tokens=_slice_optional_tensor(self.bonus_tokens, sli),
+            future_indices=future_indices,
+            new_seq_lens=_slice_optional_tensor(self.new_seq_lens, sli),
+            verify_done=self.verify_done,
+            num_correct_drafts=_slice_optional_tensor(self.num_correct_drafts, sli),
+            num_accept_tokens=_slice_optional_tensor(self.num_accept_tokens, sli),
+        )
 
     def merge_batch(self, spec_info: "EagleDraftInput"):
         if self.future_indices is not None:
@@ -996,6 +1153,193 @@ class EagleDraftExtendInput(SpecInput):
             req_to_token.size(1),
         )
         return kv_indices, cum_kv_seq_len, qo_indptr, None
+
+    def filter_batch(self, new_indices: torch.Tensor, has_been_filtered: bool = True):
+        if self.future_indices is not None:
+            self.future_indices.indices = self.future_indices.indices[new_indices]
+            if self.new_seq_lens is not None:
+                self.new_seq_lens = self.new_seq_lens[new_indices]
+            if self.hidden_states is not None:
+                self.hidden_states = self.hidden_states[new_indices]
+            if self.verified_id is not None:
+                self.verified_id = self.verified_id[new_indices]
+            if self.num_correct_drafts is not None:
+                self.num_correct_drafts = self.num_correct_drafts[new_indices]
+            if self.num_accept_tokens is not None:
+                self.num_accept_tokens = self.num_accept_tokens[new_indices]
+            if self.num_correct_drafts_cpu is not None:
+                self.num_correct_drafts_cpu = [
+                    self.num_correct_drafts_cpu[i] for i in new_indices.tolist()
+                ]
+            if self.num_accept_tokens_cpu is not None:
+                self.num_accept_tokens_cpu = [
+                    self.num_accept_tokens_cpu[i] for i in new_indices.tolist()
+                ]
+            if self.topk_p is not None:
+                self.topk_p = self.topk_p[new_indices]
+            if self.topk_index is not None:
+                self.topk_index = self.topk_index[new_indices]
+            return
+
+        strict_check = envs.SGLANG_SPEC_ENABLE_STRICT_FILTER_CHECK.get()
+        if has_been_filtered:
+            # in eagle_utils.py:verify, we have already filtered the batch by `unfinished_index`
+            # therefore, we don't need to filter the batch again in scheduler
+            error_msg = f"length of new_indices: {len(new_indices)} != length of topk_p: {len(self.topk_p)}, this should not happen"
+            if len(new_indices) != len(self.topk_p):
+                if strict_check:
+                    raise ValueError(error_msg)
+                else:
+                    logger.warning(error_msg)
+
+            self.topk_p = self.topk_p[: len(new_indices)]
+            self.topk_index = self.topk_index[: len(new_indices)]
+            self.hidden_states = self.hidden_states[: len(new_indices)]
+            self.verified_id = self.verified_id[: len(new_indices)]
+        else:
+            # in some cases(e.g draft_extend), we have not filtered the batch by `unfinished_index`
+            self.topk_p = self.topk_p[new_indices]
+            self.topk_index = self.topk_index[new_indices]
+            self.hidden_states = self.hidden_states[new_indices]
+            self.verified_id = self.verified_id[new_indices]
+
+    def slice_single(self, batch_index: int) -> "EagleDraftInput":
+        sli = slice(batch_index, batch_index + 1)
+        future_indices = None
+        if self.future_indices is not None:
+            future_indices = FutureIndices(indices=self.future_indices.indices[sli])
+        return EagleDraftInput(
+            topk_p=_slice_optional_tensor(self.topk_p, sli),
+            topk_index=_slice_optional_tensor(self.topk_index, sli),
+            hidden_states=_slice_optional_tensor(self.hidden_states, sli),
+            capture_hidden_mode=self.capture_hidden_mode,
+            verified_id=_slice_optional_tensor(self.verified_id, sli),
+            num_correct_drafts=_slice_optional_tensor(self.num_correct_drafts, sli),
+            num_accept_tokens=_slice_optional_tensor(self.num_accept_tokens, sli),
+            num_correct_drafts_cpu=(
+                None
+                if self.num_correct_drafts_cpu is None
+                else self.num_correct_drafts_cpu[batch_index : batch_index + 1]
+            ),
+            num_accept_tokens_cpu=(
+                None
+                if self.num_accept_tokens_cpu is None
+                else self.num_accept_tokens_cpu[batch_index : batch_index + 1]
+            ),
+            seq_lens_for_draft_extend=_slice_optional_tensor(
+                self.seq_lens_for_draft_extend, sli
+            ),
+            seq_lens_for_draft_extend_cpu=_slice_optional_tensor(
+                self.seq_lens_for_draft_extend_cpu, sli
+            ),
+            req_pool_indices_for_draft_extend=_slice_optional_tensor(
+                self.req_pool_indices_for_draft_extend, sli
+            ),
+            future_indices=future_indices,
+            new_seq_lens=_slice_optional_tensor(self.new_seq_lens, sli),
+            verify_done=self.verify_done,
+        )
+
+    def merge_batch(self, spec_info: "EagleDraftInput"):
+        if self.future_indices is not None:
+            assert spec_info.future_indices is not None
+            self.future_indices = FutureIndices(
+                indices=torch.cat(
+                    [self.future_indices.indices, spec_info.future_indices.indices]
+                )
+            )
+            if self.new_seq_lens is None:
+                self.new_seq_lens = spec_info.new_seq_lens
+            elif spec_info.new_seq_lens is not None:
+                self.new_seq_lens = torch.cat(
+                    [self.new_seq_lens, spec_info.new_seq_lens], axis=0
+                )
+            if self.hidden_states is None:
+                self.hidden_states = spec_info.hidden_states
+            elif spec_info.hidden_states is not None:
+                self.hidden_states = torch.cat(
+                    [self.hidden_states, spec_info.hidden_states], axis=0
+                )
+            if self.verified_id is None:
+                self.verified_id = spec_info.verified_id
+            elif spec_info.verified_id is not None:
+                self.verified_id = torch.cat(
+                    [self.verified_id, spec_info.verified_id], axis=0
+                )
+            if self.num_correct_drafts is None:
+                self.num_correct_drafts = spec_info.num_correct_drafts
+            elif spec_info.num_correct_drafts is not None:
+                self.num_correct_drafts = torch.cat(
+                    [self.num_correct_drafts, spec_info.num_correct_drafts], axis=0
+                )
+            if self.num_accept_tokens is None:
+                self.num_accept_tokens = spec_info.num_accept_tokens
+            elif spec_info.num_accept_tokens is not None:
+                self.num_accept_tokens = torch.cat(
+                    [self.num_accept_tokens, spec_info.num_accept_tokens], axis=0
+                )
+            if self.num_correct_drafts_cpu is None:
+                self.num_correct_drafts_cpu = spec_info.num_correct_drafts_cpu
+            elif spec_info.num_correct_drafts_cpu is not None:
+                self.num_correct_drafts_cpu += spec_info.num_correct_drafts_cpu
+            if self.num_accept_tokens_cpu is None:
+                self.num_accept_tokens_cpu = spec_info.num_accept_tokens_cpu
+            elif spec_info.num_accept_tokens_cpu is not None:
+                self.num_accept_tokens_cpu += spec_info.num_accept_tokens_cpu
+            if self.topk_p is None:
+                self.topk_p = spec_info.topk_p
+            elif spec_info.topk_p is not None:
+                self.topk_p = torch.cat([self.topk_p, spec_info.topk_p], axis=0)
+            if self.topk_index is None:
+                self.topk_index = spec_info.topk_index
+            elif spec_info.topk_index is not None:
+                self.topk_index = torch.cat(
+                    [self.topk_index, spec_info.topk_index], axis=0
+                )
+            return
+
+        if self.hidden_states is None:
+            self.hidden_states = spec_info.hidden_states
+            self.verified_id = spec_info.verified_id
+            self.num_correct_drafts = spec_info.num_correct_drafts
+            self.num_accept_tokens = spec_info.num_accept_tokens
+            self.num_correct_drafts_cpu = spec_info.num_correct_drafts_cpu
+            self.num_accept_tokens_cpu = spec_info.num_accept_tokens_cpu
+            self.topk_p = spec_info.topk_p
+            self.topk_index = spec_info.topk_index
+            return
+        if spec_info.hidden_states is None:
+            return
+        self.hidden_states = torch.cat(
+            [self.hidden_states, spec_info.hidden_states], axis=0
+        )
+        self.verified_id = torch.cat([self.verified_id, spec_info.verified_id], axis=0)
+        if (
+            self.num_correct_drafts is not None
+            and spec_info.num_correct_drafts is not None
+        ):
+            self.num_correct_drafts = torch.cat(
+                [self.num_correct_drafts, spec_info.num_correct_drafts], axis=0
+            )
+        if (
+            self.num_accept_tokens is not None
+            and spec_info.num_accept_tokens is not None
+        ):
+            self.num_accept_tokens = torch.cat(
+                [self.num_accept_tokens, spec_info.num_accept_tokens], axis=0
+            )
+        if (
+            self.num_correct_drafts_cpu is not None
+            and spec_info.num_correct_drafts_cpu is not None
+        ):
+            self.num_correct_drafts_cpu += spec_info.num_correct_drafts_cpu
+        if (
+            self.num_accept_tokens_cpu is not None
+            and spec_info.num_accept_tokens_cpu is not None
+        ):
+            self.num_accept_tokens_cpu += spec_info.num_accept_tokens_cpu
+        self.topk_p = torch.cat([self.topk_p, spec_info.topk_p])
+        self.topk_index = torch.cat([self.topk_index, spec_info.topk_index])
 
 
 @dataclass

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -19,6 +19,7 @@ from sglang.srt.managers.utils import get_alloc_len_per_decode
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_token_slots,
+    evict_from_tree_cache,
     get_last_loc,
 )
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
@@ -151,15 +152,40 @@ class EagleDraftInputV2Mixin:
                 batch.req_pool_indices,
                 cur_kv_lens,
             )
-            out_cache_loc = alloc_paged_token_slots_extend(
-                batch.tree_cache,
-                cur_kv_lens,
-                cur_kv_lens_cpu,
-                nxt_kv_lens,
-                nxt_kv_lens_cpu,
-                last_loc,
-                num_needed_tokens,
-            )
+            hisparse_coordinator = batch.hisparse_coordinator
+            if (
+                hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                allocator = batch.tree_cache.token_to_kv_pool_allocator
+                evict_from_tree_cache(
+                    batch.tree_cache,
+                    num_needed_tokens + len(cur_kv_lens_cpu) * allocator.page_size,
+                )
+                device_slots = hisparse_coordinator.get_draft_device_slots_variable(
+                    batch.req_pool_indices,
+                    nxt_kv_lens_cpu - cur_kv_lens_cpu,
+                    cur_kv_lens_cpu,
+                )
+                out_cache_loc = allocator.alloc_extend_with_device_mapping(
+                    cur_kv_lens,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                    device_slots,
+                )
+            else:
+                out_cache_loc = alloc_paged_token_slots_extend(
+                    batch.tree_cache,
+                    cur_kv_lens,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                )
 
         assign_req_to_token_pool_func(
             batch.req_pool_indices,
@@ -276,6 +302,17 @@ class EagleVerifyInputV2Mixin:
                 draft_token_num=self.draft_token_num,
                 device=device,
             )
+            hisparse_coordinator = batch.hisparse_coordinator
+            if (
+                hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                hisparse_coordinator.prepare_verify_slots_spec_v2(
+                    req_pool_indices=batch.req_pool_indices,
+                    verify_cache_locs=batch.out_cache_loc,
+                    num_tokens_per_req=self.draft_token_num,
+                    start_positions_cpu=batch.seq_lens_cpu,
+                )
 
             # Set mamba_track_indices for mamba prefix-cache state tracking
             if get_global_server_args().enable_mamba_extra_buffer():

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -527,6 +527,7 @@ class EAGLEWorker(TpModelWorker):
                     next_draft_input = self.forward_draft_extend_after_decode(batch)
                     batch.spec_info = next_draft_input
                 else:
+                    self._clear_hisparse_pending_draft_extend_backup(batch)
                     # All reqs finished and dp_attention isn't forcing extend.
                     # Install an idle EagleDraftInput so next iter's scheduler
                     # ops (merge_batch / filter_batch) see well-typed empty
@@ -567,6 +568,22 @@ class EAGLEWorker(TpModelWorker):
         global_need_forward_cnt = global_need_forward[0].item()
         need_forward = global_need_forward_cnt > 0
         return need_forward
+
+    def _finish_hisparse_pending_draft_extend_backup(self, batch: ScheduleBatch):
+        hisparse_coordinator = getattr(batch, "hisparse_coordinator", None)
+        if (
+            hisparse_coordinator is not None
+            and hisparse_coordinator.supports_hisparse_draft_slots()
+        ):
+            hisparse_coordinator.finish_pending_draft_extend_backup()
+
+    def _clear_hisparse_pending_draft_extend_backup(self, batch: ScheduleBatch):
+        hisparse_coordinator = getattr(batch, "hisparse_coordinator", None)
+        if (
+            hisparse_coordinator is not None
+            and hisparse_coordinator.supports_hisparse_draft_slots()
+        ):
+            hisparse_coordinator.clear_pending_draft_extend_backup()
 
     def forward_target_extend(
         self, batch: ScheduleBatch
@@ -1199,6 +1216,7 @@ class EAGLEWorker(TpModelWorker):
             else CaptureHiddenMode.LAST
         )
         if draft_extend_input.input_ids.shape[0] == 0:
+            self._clear_hisparse_pending_draft_extend_backup(batch)
             # Single source for hidden_size via hidden_size_for(self) (incl.
             # EAGLE-3 aux widening). Two stub origins from verify(): fully-idle
             # batch (DP attn rank w/o reqs) and active batch with all reqs
@@ -1271,6 +1289,7 @@ class EAGLEWorker(TpModelWorker):
             topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
             hidden_states = logits_output.hidden_states
 
+        self._finish_hisparse_pending_draft_extend_backup(batch)
         maybe_detect_nan(
             logits_output.next_token_logits,
             f"draft_extend_after_decode (cuda_graph={can_cuda_graph})",

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -23,6 +23,7 @@ from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_token_slots,
+    evict_from_tree_cache,
     get_last_loc,
 )
 from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
@@ -678,18 +679,46 @@ class EAGLEWorker(TpModelWorker):
                 )
                 extend_num_tokens = torch.sum((seq_lens_cpu - prefix_lens_cpu)).item()
 
-            out_cache_loc, token_to_kv_pool_state_backup = (
-                alloc_paged_token_slots_extend(
+            hisparse_coordinator = batch.hisparse_coordinator
+            if (
+                hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                allocator = self.token_to_kv_pool_allocator
+                evict_from_tree_cache(
                     batch.tree_cache,
-                    prefix_lens,
-                    prefix_lens_cpu,
-                    seq_lens,
-                    seq_lens_cpu,
-                    last_loc,
-                    extend_num_tokens,
-                    backup_state=True,
+                    extend_num_tokens + len(prefix_lens_cpu) * allocator.page_size,
                 )
-            )
+                device_slots = hisparse_coordinator.get_draft_device_slots_variable(
+                    batch.req_pool_indices,
+                    seq_lens_cpu - prefix_lens_cpu,
+                    prefix_lens_cpu,
+                )
+                out_cache_loc, token_to_kv_pool_state_backup = (
+                    allocator.alloc_extend_with_device_mapping(
+                        prefix_lens,
+                        prefix_lens_cpu,
+                        seq_lens,
+                        seq_lens_cpu,
+                        last_loc,
+                        extend_num_tokens,
+                        device_slots,
+                        backup_state=True,
+                    )
+                )
+            else:
+                out_cache_loc, token_to_kv_pool_state_backup = (
+                    alloc_paged_token_slots_extend(
+                        batch.tree_cache,
+                        prefix_lens,
+                        prefix_lens_cpu,
+                        seq_lens,
+                        seq_lens_cpu,
+                        last_loc,
+                        extend_num_tokens,
+                        backup_state=True,
+                    )
+                )
 
         if self.page_size > 1 and self.topk > 1:
             last_page_lens_cumsum = torch.cumsum(last_page_lens, dim=0)

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1073,6 +1073,19 @@ class EAGLEWorkerV2(BaseSpecWorker):
         ) = verify_input.sample(batch, logits_output, vocab_mask)
         new_seq_lens = batch.seq_lens + accept_lens
 
+        hisparse_coordinator = batch.hisparse_coordinator
+        if (
+            hisparse_coordinator is not None
+            and hisparse_coordinator.supports_hisparse_draft_slots()
+            and not batch.forward_mode.is_idle()
+        ):
+            hisparse_coordinator.finalize_accepted_tokens_spec_v2(
+                req_pool_indices=batch.req_pool_indices,
+                seq_lens=batch.seq_lens,
+                verify_cache_locs=batch.out_cache_loc,
+                accept_index=accept_index,
+            )
+
         # Update mamba state for hybrid GDN models after verification
         if (
             self.target_worker.model_runner.hybrid_gdn_config is not None

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -65,6 +65,32 @@ struct PDRequestContext<'a> {
     headers: Option<HeaderMap>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorkerDispatchOutcome {
+    Http(StatusCode),
+    TransportError,
+}
+
+impl WorkerDispatchOutcome {
+    fn from_result(result: &Result<reqwest::Response, reqwest::Error>) -> Self {
+        match result {
+            Ok(response) => Self::Http(response.status()),
+            Err(_) => Self::TransportError,
+        }
+    }
+
+    fn is_server_or_transport_error(self) -> bool {
+        match self {
+            Self::Http(status) => status.is_server_error(),
+            Self::TransportError => true,
+        }
+    }
+
+    fn is_success(self) -> bool {
+        matches!(self, Self::Http(status) if status.is_success())
+    }
+}
+
 impl PDRouter {
     async fn proxy_to_first_prefill_worker(
         &self,
@@ -179,6 +205,75 @@ impl PDRouter {
     fn handle_serialization_error(error: impl std::fmt::Display) -> Response {
         error!("Failed to serialize request error={}", error);
         error::internal_error("serialization_failed", "Failed to serialize request")
+    }
+
+    fn record_worker_http_status(
+        worker: &Arc<dyn Worker>,
+        worker_label: &'static str,
+        status: StatusCode,
+    ) {
+        let not_error = status.is_success() || status.is_client_error();
+        worker.record_outcome(not_error);
+
+        if status.is_server_error() {
+            Metrics::record_worker_error(
+                worker_label,
+                metrics_labels::CONNECTION_HTTP,
+                error_type_from_status(status),
+            );
+        }
+    }
+
+    fn record_worker_transport_error(worker: &Arc<dyn Worker>, worker_label: &'static str) {
+        worker.record_outcome(false);
+        Metrics::record_worker_error(
+            worker_label,
+            metrics_labels::CONNECTION_HTTP,
+            error_type_from_status(StatusCode::BAD_GATEWAY),
+        );
+    }
+
+    fn record_worker_dispatch_outcome(
+        worker: &Arc<dyn Worker>,
+        worker_label: &'static str,
+        outcome: WorkerDispatchOutcome,
+    ) {
+        match outcome {
+            WorkerDispatchOutcome::Http(status) => {
+                Self::record_worker_http_status(worker, worker_label, status)
+            }
+            WorkerDispatchOutcome::TransportError => {
+                Self::record_worker_transport_error(worker, worker_label)
+            }
+        }
+    }
+
+    fn record_pd_worker_outcomes(
+        prefill: &Arc<dyn Worker>,
+        decode: &Arc<dyn Worker>,
+        prefill_outcome: WorkerDispatchOutcome,
+        decode_outcome: WorkerDispatchOutcome,
+    ) {
+        Self::record_worker_dispatch_outcome(decode, metrics_labels::WORKER_DECODE, decode_outcome);
+
+        if decode_outcome.is_server_or_transport_error()
+            && prefill_outcome.is_server_or_transport_error()
+        {
+            debug!(
+                prefill_url = prefill.url(),
+                decode_url = decode.url(),
+                ?prefill_outcome,
+                ?decode_outcome,
+                "Skipping prefill circuit failure because decode request already failed"
+            );
+            return;
+        }
+
+        Self::record_worker_dispatch_outcome(
+            prefill,
+            metrics_labels::WORKER_PREFILL,
+            prefill_outcome,
+        );
     }
 
     fn get_generate_batch_size(req: &GenerateRequest) -> Option<usize> {
@@ -351,26 +446,6 @@ impl PDRouter {
                                 start_time,
                             )
                             .await;
-
-                        let status = response.status();
-                        let not_error = status.is_success() || status.is_client_error();
-                        prefill.record_outcome(not_error);
-                        decode.record_outcome(not_error);
-
-                        // Record worker errors for server errors (5xx)
-                        if status.is_server_error() {
-                            let error_type = error_type_from_status(status);
-                            Metrics::record_worker_error(
-                                metrics_labels::WORKER_PREFILL,
-                                metrics_labels::CONNECTION_HTTP,
-                                error_type,
-                            );
-                            Metrics::record_worker_error(
-                                metrics_labels::WORKER_DECODE,
-                                metrics_labels::CONNECTION_HTTP,
-                                error_type,
-                            );
-                        }
 
                         response
                     }
@@ -557,7 +632,7 @@ impl PDRouter {
             context.route,
             &json_request,
             headers,
-            false,
+            true,
         );
         let decode_request = self.build_post_with_headers(
             &self.client,
@@ -565,21 +640,106 @@ impl PDRouter {
             context.route,
             &json_request,
             headers,
-            false,
+            true,
         );
 
-        // Send both requests concurrently and wait for both
-        // Note: Using borrowed references avoids heap allocation
+        // Send both requests concurrently. Prefill is the dependency that can
+        // unblock decode KV transfer, so fail fast on prefill send/status errors
+        // instead of waiting for decode to time out with no KV cache.
         events::RequestPDSentEvent {
             prefill_url: prefill.url(),
             decode_url: decode.url(),
         }
         .emit();
 
-        let (prefill_result, decode_result) =
-            tokio::join!(prefill_request.send(), decode_request.send());
+        let prefill_task = tokio::spawn(prefill_request.send());
+        let decode_task = tokio::spawn(decode_request.send());
+
+        let prefill_result = match prefill_task.await {
+            Ok(result) => result,
+            Err(e) => {
+                decode_task.abort();
+                let _ = decode_task.await;
+                Self::record_worker_dispatch_outcome(
+                    &prefill,
+                    metrics_labels::WORKER_PREFILL,
+                    WorkerDispatchOutcome::TransportError,
+                );
+                error!(
+                    prefill_url = %prefill.url(),
+                    error = %e,
+                    "Prefill request task failed"
+                );
+                return error::bad_gateway(
+                    "prefill_server_error",
+                    format!("Prefill request task failed: {}", e),
+                );
+            }
+        };
+
+        let prefill_outcome = WorkerDispatchOutcome::from_result(&prefill_result);
+        if !prefill_outcome.is_success() {
+            decode_task.abort();
+            let _ = decode_task.await;
+            Self::record_worker_dispatch_outcome(
+                &prefill,
+                metrics_labels::WORKER_PREFILL,
+                prefill_outcome,
+            );
+            return match self
+                .process_prefill_response(prefill_result, prefill.url(), context.return_logprob)
+                .await
+            {
+                Ok((_, _)) => error::bad_gateway(
+                    "prefill_server_error",
+                    "Prefill request did not complete successfully",
+                ),
+                Err(error_response) => error_response,
+            };
+        }
+
+        let prefill_body = match self
+            .process_prefill_response(prefill_result, prefill.url(), context.return_logprob)
+            .await
+        {
+            Ok((_, body)) => body,
+            Err(error_response) => {
+                decode_task.abort();
+                let _ = decode_task.await;
+                Self::record_worker_dispatch_outcome(
+                    &prefill,
+                    metrics_labels::WORKER_PREFILL,
+                    prefill_outcome,
+                );
+                return error_response;
+            }
+        };
+
+        let decode_result = match decode_task.await {
+            Ok(result) => result,
+            Err(e) => {
+                Self::record_pd_worker_outcomes(
+                    &prefill,
+                    &decode,
+                    prefill_outcome,
+                    WorkerDispatchOutcome::TransportError,
+                );
+                error!(
+                    decode_url = %decode.url(),
+                    error = %e,
+                    "Decode request task failed"
+                );
+                return error::bad_gateway(
+                    "decode_server_error",
+                    format!("Decode request task failed: {}", e),
+                );
+            }
+        };
 
         events::RequestReceivedEvent {}.emit();
+
+        let decode_outcome = WorkerDispatchOutcome::from_result(&decode_result);
+        Self::record_pd_worker_outcomes(&prefill, &decode, prefill_outcome, decode_outcome);
 
         // Process decode response
         match decode_result {
@@ -599,30 +759,6 @@ impl PDRouter {
                         .handle_decode_error_response(res, &context, prefill, decode)
                         .await;
                 }
-
-                // Process prefill response
-                let prefill_body = if context.return_logprob {
-                    match self
-                        .process_prefill_response(
-                            prefill_result,
-                            prefill.url(),
-                            context.return_logprob,
-                        )
-                        .await
-                    {
-                        Ok((_, body)) => body,
-                        Err(error_response) => return error_response,
-                    }
-                } else {
-                    // Even if we don't need logprobs, we should check prefill status
-                    match self
-                        .process_prefill_response(prefill_result, prefill.url(), false)
-                        .await
-                    {
-                        Ok((_, body)) => body,
-                        Err(error_response) => return error_response,
-                    }
-                };
 
                 if context.is_stream {
                     // Streaming response
@@ -802,10 +938,30 @@ impl PDRouter {
             .collect();
 
         if available_workers.is_empty() {
-            return Err(format!(
-                "No available {} workers (all circuits open or unhealthy)",
-                worker_type
-            ));
+            let healthy_workers: Vec<Arc<dyn Worker>> =
+                workers.iter().filter(|w| w.is_healthy()).cloned().collect();
+
+            if healthy_workers.is_empty() {
+                return Err(format!(
+                    "No available {} workers (all circuits open or unhealthy)",
+                    worker_type
+                ));
+            }
+
+            warn!(
+                worker_type = worker_type,
+                healthy_worker_count = healthy_workers.len(),
+                "All healthy PD workers are circuit-open; falling back to lowest-load health-only selection"
+            );
+            return healthy_workers
+                .into_iter()
+                .min_by_key(|worker| worker.load())
+                .ok_or_else(|| {
+                    format!(
+                        "No available {} workers (all circuits open or unhealthy)",
+                        worker_type
+                    )
+                });
         }
 
         let selected_idx = policy
@@ -955,7 +1111,7 @@ impl PDRouter {
             Ok(response) => response,
             Err(e) => {
                 error!(
-                    "Prefill server failed (CRITICAL) prefill_url={} error={}. Decode will timeout without prefill KV cache.",
+                    "Prefill server failed (CRITICAL) prefill_url={} error={}. Aborting decode dispatch before it waits for missing KV cache.",
                     prefill_url,
                     e
                 );
@@ -963,10 +1119,7 @@ impl PDRouter {
                 // Return error immediately - don't wait for decode to timeout
                 return Err(error::bad_gateway(
                     "prefill_server_error",
-                    format!(
-                        "Prefill server error: {}. This will cause decode timeout.",
-                        e
-                    ),
+                    format!("Prefill server error: {}. Decode dispatch was aborted.", e),
                 ));
             }
         };
@@ -1508,6 +1661,144 @@ mod tests {
 
         assert_eq!(prefill_worker.load(), 0);
         assert_eq!(decode_worker.load(), 0);
+    }
+
+    #[test]
+    fn test_decode_server_error_does_not_open_prefill_circuit() {
+        let prefill_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://prefill".to_string(),
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+            true,
+        ));
+        let decode_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+            true,
+        ));
+
+        for _ in 0..12 {
+            PDRouter::record_pd_worker_outcomes(
+                &prefill_worker,
+                &decode_worker,
+                WorkerDispatchOutcome::Http(StatusCode::INTERNAL_SERVER_ERROR),
+                WorkerDispatchOutcome::Http(StatusCode::INTERNAL_SERVER_ERROR),
+            );
+        }
+
+        assert!(prefill_worker.circuit_breaker().can_execute());
+        assert_eq!(prefill_worker.circuit_breaker().consecutive_failures(), 0);
+        assert!(!decode_worker.circuit_breaker().can_execute());
+    }
+
+    #[test]
+    fn test_prefill_server_error_opens_prefill_circuit_when_decode_succeeds() {
+        let prefill_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://prefill".to_string(),
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+            true,
+        ));
+        let decode_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+            true,
+        ));
+
+        for _ in 0..12 {
+            PDRouter::record_pd_worker_outcomes(
+                &prefill_worker,
+                &decode_worker,
+                WorkerDispatchOutcome::Http(StatusCode::INTERNAL_SERVER_ERROR),
+                WorkerDispatchOutcome::Http(StatusCode::OK),
+            );
+        }
+
+        assert!(!prefill_worker.circuit_breaker().can_execute());
+        assert!(decode_worker.circuit_breaker().can_execute());
+    }
+
+    #[test]
+    fn test_decode_server_error_records_prefill_success_when_prefill_succeeds() {
+        let prefill_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://prefill".to_string(),
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+            true,
+        ));
+        let decode_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+            true,
+        ));
+
+        PDRouter::record_pd_worker_outcomes(
+            &prefill_worker,
+            &decode_worker,
+            WorkerDispatchOutcome::Http(StatusCode::INTERNAL_SERVER_ERROR),
+            WorkerDispatchOutcome::Http(StatusCode::OK),
+        );
+        assert_eq!(prefill_worker.circuit_breaker().consecutive_failures(), 1);
+
+        PDRouter::record_pd_worker_outcomes(
+            &prefill_worker,
+            &decode_worker,
+            WorkerDispatchOutcome::Http(StatusCode::OK),
+            WorkerDispatchOutcome::Http(StatusCode::INTERNAL_SERVER_ERROR),
+        );
+
+        assert!(prefill_worker.circuit_breaker().can_execute());
+        assert_eq!(prefill_worker.circuit_breaker().consecutive_failures(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_pick_worker_falls_back_to_healthy_when_circuit_open() {
+        let router = create_test_pd_router();
+        let decode_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+            true,
+        ));
+
+        for _ in 0..12 {
+            decode_worker.record_outcome(false);
+        }
+
+        assert!(decode_worker.is_healthy());
+        assert!(!decode_worker.is_available());
+
+        let workers = vec![decode_worker.clone()];
+        let policy = router.policy_registry.get_decode_policy();
+        let selected =
+            PDRouter::pick_worker_by_policy_arc(&workers, &*policy, None, None, None, "decode")
+                .await
+                .unwrap();
+
+        assert_eq!(selected.url(), "http://decode");
+    }
+
+    #[test]
+    fn test_build_post_with_headers_can_close_connection() {
+        let router = create_test_pd_router();
+        let request = router
+            .build_post_with_headers(
+                &router.client,
+                "http://prefill",
+                "/v1/chat/completions",
+                &serde_json::json!({"model": "test"}),
+                None,
+                true,
+            )
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request.headers().get("connection"),
+            Some(&HeaderValue::from_static("close"))
+        );
     }
 
     #[tokio::test]

--- a/test/registered/unit/disaggregation/test_mooncake_hisparse.py
+++ b/test/registered/unit/disaggregation/test_mooncake_hisparse.py
@@ -1,0 +1,51 @@
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+class TestMooncakeHiSparseTransfer(unittest.TestCase):
+    def test_hisparse_transfer_uses_only_target_kv_group(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.kv_args = SimpleNamespace(
+            page_size=4,
+            kv_data_ptrs=[100, 200, 300],
+            kv_item_lens=[40, 80, 120],
+            target_kv_data_ptr_count=2,
+        )
+        captured = {}
+
+        def capture_send(**kwargs):
+            captured.update(kwargs)
+            return 0
+
+        manager._send_kvcache_generic = capture_send
+
+        ret = manager.send_kvcache_hisparse(
+            mooncake_session_id="session",
+            prefill_kv_indices=np.array([5], dtype=np.int32),
+            dst_kv_ptrs=[1000, 2000],
+            dst_kv_indices=np.array([10, 11, 12, 13], dtype=np.int32),
+            page_index_slice=slice(0, 1),
+            executor=None,
+        )
+
+        self.assertEqual(ret, 0)
+        self.assertEqual(captured["src_data_ptrs"], [100, 200])
+        self.assertEqual(captured["dst_data_ptrs"], [1000, 2000])
+        self.assertEqual(captured["item_lens"], [10, 20])
+        np.testing.assert_array_equal(
+            captured["prefill_data_indices"], np.array([20, 21, 22, 23])
+        )
+        np.testing.assert_array_equal(
+            captured["dst_data_indices"], np.array([10, 11, 12, 13])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_prefill_bootstrap_admission.py
+++ b/test/registered/unit/disaggregation/test_prefill_bootstrap_admission.py
@@ -1,0 +1,245 @@
+import threading
+import time
+import types
+import unittest
+from collections import defaultdict, deque
+from types import SimpleNamespace
+
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.mooncake.conn import (
+    MooncakeKVManager,
+    MooncakeKVReceiver,
+    MooncakeKVSender,
+    TransferKVChunk,
+)
+from sglang.srt.disaggregation.prefill import PrefillBootstrapQueue
+from sglang.srt.disaggregation.utils import ReqToMetadataIdxAllocator
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+def _make_req(rid: str):
+    return SimpleNamespace(
+        rid=rid,
+        origin_input_ids=[1, 2, 3],
+        sampling_params=SimpleNamespace(max_new_tokens=8),
+        finished_reason=None,
+        return_logprob=False,
+        disagg_kv_sender=None,
+    )
+
+
+def _make_queue(capacity: int):
+    queue = PrefillBootstrapQueue.__new__(PrefillBootstrapQueue)
+    queue.queue = []
+    queue.pending_queue = deque()
+    queue.req_to_metadata_buffer_idx_allocator = ReqToMetadataIdxAllocator(capacity)
+    queue.max_total_num_tokens = 1024
+    queue.scheduler = SimpleNamespace(
+        waiting_queue=[],
+        disagg_prefill_inflight_queue=[],
+        cur_batch=None,
+        last_batch=None,
+        running_batch=SimpleNamespace(reqs=[]),
+        model_config=SimpleNamespace(num_key_value_heads=1),
+    )
+
+    def fake_create_kv_sender(self, req, num_kv_heads):
+        req.disagg_kv_sender = object()
+        self.queue.append(req)
+
+    queue._create_kv_sender = types.MethodType(fake_create_kv_sender, queue)
+    return queue
+
+
+class TestPrefillBootstrapAdmission(unittest.TestCase):
+    def test_admission_defers_requests_without_sender(self):
+        queue = _make_queue(capacity=2)
+        reqs = [_make_req(f"req-{i}") for i in range(3)]
+
+        for req in reqs:
+            queue.add(req, num_kv_heads=1)
+
+        self.assertEqual([req.rid for req in queue.queue], ["req-0", "req-1"])
+        self.assertEqual([req.rid for req in queue.pending_queue], ["req-2"])
+        self.assertIsNotNone(reqs[0].disagg_kv_sender)
+        self.assertIsNotNone(reqs[1].disagg_kv_sender)
+        self.assertIsNone(reqs[2].disagg_kv_sender)
+
+    def test_pending_request_admits_when_active_sender_finishes(self):
+        queue = _make_queue(capacity=2)
+        reqs = [_make_req(f"req-{i}") for i in range(3)]
+        for req in reqs:
+            queue.add(req, num_kv_heads=1)
+
+        queue.queue.pop(0)
+        queue._admit_pending(num_kv_heads=1)
+
+        self.assertEqual([req.rid for req in queue.queue], ["req-1", "req-2"])
+        self.assertEqual(list(queue.pending_queue), [])
+        self.assertIsNotNone(reqs[2].disagg_kv_sender)
+
+    def test_waiting_and_inflight_reqs_count_against_admission(self):
+        queue = _make_queue(capacity=2)
+        active_waiting = _make_req("waiting")
+        active_waiting.disagg_kv_sender = object()
+        queue.scheduler.waiting_queue = [active_waiting]
+
+        queue.add(_make_req("req-0"), num_kv_heads=1)
+        queue.add(_make_req("req-1"), num_kv_heads=1)
+
+        self.assertEqual([req.rid for req in queue.queue], ["req-0"])
+        self.assertEqual([req.rid for req in queue.pending_queue], ["req-1"])
+
+    def test_running_batch_reqs_count_against_admission(self):
+        queue = _make_queue(capacity=2)
+        active_running = _make_req("running")
+        active_running.disagg_kv_sender = object()
+        queue.scheduler.running_batch = SimpleNamespace(reqs=[active_running])
+
+        queue.add(_make_req("req-0"), num_kv_heads=1)
+        queue.add(_make_req("req-1"), num_kv_heads=1)
+
+        self.assertEqual([req.rid for req in queue.queue], ["req-0"])
+        self.assertEqual([req.rid for req in queue.pending_queue], ["req-1"])
+
+    def test_mooncake_sender_bootstrap_timeout_starts_after_metadata_arrives(self):
+        class FakeKVManager:
+            bootstrap_timeout = 60.0
+            transfer_infos = {}
+
+            def check_status(self, bootstrap_room):
+                return KVPoll.Bootstrapping
+
+        sender = MooncakeKVSender.__new__(MooncakeKVSender)
+        sender.conclude_state = None
+        sender.kv_mgr = FakeKVManager()
+        sender.bootstrap_room = 7
+        sender.init_time = None
+
+        self.assertEqual(sender.poll(), KVPoll.Bootstrapping)
+        self.assertIsNone(sender.init_time)
+
+        sender.kv_mgr.transfer_infos[sender.bootstrap_room] = {"session": object()}
+        before_poll = time.time()
+
+        self.assertEqual(sender.poll(), KVPoll.Bootstrapping)
+        self.assertIsNotNone(sender.init_time)
+        self.assertGreaterEqual(sender.init_time, before_poll)
+
+    def test_mooncake_receiver_waiting_timeout_starts_after_transfer_begins(self):
+        class FakeKVManager:
+            waiting_timeout = 60.0
+
+            def __init__(self):
+                self.status = KVPoll.WaitingForInput
+                self.failures = []
+
+            def check_status(self, bootstrap_room):
+                return self.status
+
+            def record_failure(self, bootstrap_room, reason):
+                self.failures.append((bootstrap_room, reason))
+
+        receiver = MooncakeKVReceiver.__new__(MooncakeKVReceiver)
+        receiver.conclude_state = None
+        receiver.kv_mgr = FakeKVManager()
+        receiver.bootstrap_room = 11
+        receiver.init_time = None
+
+        self.assertEqual(receiver.poll(), KVPoll.WaitingForInput)
+        self.assertIsNone(receiver.init_time)
+        self.assertEqual(receiver.kv_mgr.failures, [])
+
+        receiver.kv_mgr.status = KVPoll.Transferring
+        before_poll = time.time()
+
+        self.assertEqual(receiver.poll(), KVPoll.Transferring)
+        self.assertIsNotNone(receiver.init_time)
+        self.assertGreaterEqual(receiver.init_time, before_poll)
+
+        receiver.init_time = time.time() - receiver.kv_mgr.waiting_timeout - 1
+
+        self.assertEqual(receiver.poll(), KVPoll.Failed)
+        self.assertIn("KVPoll.Transferring", receiver.kv_mgr.failures[0][1])
+
+    def test_mooncake_transfer_worker_drops_failed_room_without_transfer(self):
+        class StopLoop(BaseException):
+            pass
+
+        class OneChunkQueue:
+            def __init__(self, chunk):
+                self.chunk = chunk
+                self.calls = 0
+
+            def get(self):
+                self.calls += 1
+                if self.calls == 1:
+                    return self.chunk
+                raise StopLoop()
+
+        manager = SimpleNamespace()
+        manager.enable_staging = False
+        manager.transfer_infos = {3: {"session": object()}}
+        manager.req_to_decode_prefix_len = {3: 0}
+        manager.request_status = {3: KVPoll.Failed}
+
+        chunk = TransferKVChunk(
+            room=3,
+            prefill_kv_indices=[],
+            index_slice=slice(0, 0),
+            is_last_chunk=True,
+            prefill_aux_index=0,
+            state_indices=None,
+        )
+
+        with self.assertRaises(StopLoop):
+            MooncakeKVManager.transfer_worker(manager, OneChunkQueue(chunk), None)
+
+        self.assertEqual(manager.transfer_infos, {})
+        self.assertEqual(manager.req_to_decode_prefix_len, {})
+
+    def test_decode_status_success_ignores_cleared_room(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.status_lock = threading.RLock()
+        manager.request_status = {}
+        manager.required_prefill_response_num_table = {7: 1}
+        manager.prefill_response_tracker = defaultdict(set)
+        manager.enable_staging = False
+
+        MooncakeKVManager._handle_decode_status(manager, 7, KVPoll.Success, 0)
+
+        self.assertNotIn(7, manager.request_status)
+        self.assertNotIn(7, manager.prefill_response_tracker)
+
+    def test_decode_status_success_ignores_missing_response_count(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.status_lock = threading.RLock()
+        manager.request_status = {7: KVPoll.Transferring}
+        manager.required_prefill_response_num_table = {}
+        manager.prefill_response_tracker = defaultdict(set)
+        manager.enable_staging = False
+
+        MooncakeKVManager._handle_decode_status(manager, 7, KVPoll.Success, 0)
+
+        self.assertEqual(manager.request_status[7], KVPoll.Transferring)
+        self.assertNotIn(7, manager.prefill_response_tracker)
+
+    def test_decode_status_success_completes_after_required_responses(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.status_lock = threading.RLock()
+        manager.request_status = {7: KVPoll.Transferring}
+        manager.required_prefill_response_num_table = {7: 2}
+        manager.prefill_response_tracker = defaultdict(set)
+        manager.enable_staging = False
+
+        MooncakeKVManager._handle_decode_status(manager, 7, KVPoll.Success, 0)
+        self.assertEqual(manager.request_status[7], KVPoll.Transferring)
+
+        MooncakeKVManager._handle_decode_status(manager, 7, KVPoll.Success, 1)
+        self.assertEqual(manager.request_status[7], KVPoll.Success)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_prefill_bootstrap_admission.py
+++ b/test/registered/unit/disaggregation/test_prefill_bootstrap_admission.py
@@ -104,29 +104,94 @@ class TestPrefillBootstrapAdmission(unittest.TestCase):
         self.assertEqual([req.rid for req in queue.queue], ["req-0"])
         self.assertEqual([req.rid for req in queue.pending_queue], ["req-1"])
 
-    def test_mooncake_sender_bootstrap_timeout_starts_after_metadata_arrives(self):
+    def test_mooncake_sender_bootstrap_timeout_starts_when_sender_is_created(self):
         class FakeKVManager:
             bootstrap_timeout = 60.0
-            transfer_infos = {}
 
             def check_status(self, bootstrap_room):
                 return KVPoll.Bootstrapping
+
+            def record_failure(self, bootstrap_room, reason):
+                raise AssertionError("bootstrap should not fail before timeout")
+
+            def update_status(self, bootstrap_room, status):
+                raise AssertionError("bootstrap should not update before timeout")
 
         sender = MooncakeKVSender.__new__(MooncakeKVSender)
         sender.conclude_state = None
         sender.kv_mgr = FakeKVManager()
         sender.bootstrap_room = 7
-        sender.init_time = None
+        before_poll = time.time()
+        sender.init_time = before_poll
+        sender.transfer_init_time = None
 
         self.assertEqual(sender.poll(), KVPoll.Bootstrapping)
-        self.assertIsNone(sender.init_time)
+        self.assertEqual(sender.init_time, before_poll)
 
-        sender.kv_mgr.transfer_infos[sender.bootstrap_room] = {"session": object()}
+    def test_mooncake_sender_bootstrap_timeout_fails_without_decode_metadata(self):
+        class FakeKVManager:
+            bootstrap_timeout = 60.0
+
+            def __init__(self):
+                self.status = KVPoll.Bootstrapping
+                self.failures = []
+
+            def check_status(self, bootstrap_room):
+                return self.status
+
+            def record_failure(self, bootstrap_room, reason):
+                self.failures.append((bootstrap_room, reason))
+
+            def update_status(self, bootstrap_room, status):
+                self.status = status
+
+        sender = MooncakeKVSender.__new__(MooncakeKVSender)
+        sender.conclude_state = None
+        sender.kv_mgr = FakeKVManager()
+        sender.bootstrap_room = 7
+        sender.init_time = time.time() - sender.kv_mgr.bootstrap_timeout - 1
+        sender.transfer_init_time = None
+
+        self.assertEqual(sender.poll(), KVPoll.Failed)
+        self.assertEqual(sender.kv_mgr.status, KVPoll.Failed)
+        self.assertIn("KVPoll.Bootstrapping", sender.kv_mgr.failures[0][1])
+
+    def test_mooncake_sender_transfer_timeout_fails_inflight_request(self):
+        class FakeKVManager:
+            waiting_timeout = 60.0
+
+            def __init__(self):
+                self.status = KVPoll.Transferring
+                self.failures = []
+
+            def check_status(self, bootstrap_room):
+                return self.status
+
+            def record_failure(self, bootstrap_room, reason):
+                self.failures.append((bootstrap_room, reason))
+
+            def update_status(self, bootstrap_room, status):
+                self.status = status
+
+        sender = MooncakeKVSender.__new__(MooncakeKVSender)
+        sender.conclude_state = None
+        sender.kv_mgr = FakeKVManager()
+        sender.bootstrap_room = 17
+        sender.init_time = None
+        sender.transfer_init_time = None
+
         before_poll = time.time()
 
-        self.assertEqual(sender.poll(), KVPoll.Bootstrapping)
-        self.assertIsNotNone(sender.init_time)
-        self.assertGreaterEqual(sender.init_time, before_poll)
+        self.assertEqual(sender.poll(), KVPoll.Transferring)
+        self.assertIsNotNone(sender.transfer_init_time)
+        self.assertGreaterEqual(sender.transfer_init_time, before_poll)
+        self.assertEqual(sender.kv_mgr.failures, [])
+
+        sender.transfer_init_time = time.time() - sender.kv_mgr.waiting_timeout - 1
+
+        self.assertEqual(sender.poll(), KVPoll.Failed)
+        self.assertEqual(sender.kv_mgr.status, KVPoll.Failed)
+        self.assertIn("KVPoll.Transferring", sender.kv_mgr.failures[0][1])
 
     def test_mooncake_receiver_waiting_timeout_starts_after_transfer_begins(self):
         class FakeKVManager:
@@ -239,6 +304,125 @@ class TestPrefillBootstrapAdmission(unittest.TestCase):
 
         MooncakeKVManager._handle_decode_status(manager, 7, KVPoll.Success, 1)
         self.assertEqual(manager.request_status[7], KVPoll.Success)
+
+    def test_prefill_decode_status_failed_marks_bootstrap_failed(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.status_lock = threading.RLock()
+        manager.failure_lock = threading.Lock()
+        manager.request_status = {7: KVPoll.Bootstrapping}
+        manager.failure_records = {}
+        manager.transfer_infos = {7: {"session": object()}}
+        manager.req_to_decode_prefix_len = {7: 42}
+
+        MooncakeKVManager._handle_prefill_decode_status(
+            manager,
+            [
+                MooncakeKVManager.DECODE_STATUS_HEADER,
+                b"7",
+                str(KVPoll.Failed).encode("ascii"),
+                b"decode aborted before metadata",
+            ],
+        )
+
+        self.assertEqual(manager.request_status[7], KVPoll.Failed)
+        self.assertEqual(manager.failure_records[7], "decode aborted before metadata")
+        self.assertNotIn(7, manager.transfer_infos)
+        self.assertNotIn(7, manager.req_to_decode_prefix_len)
+
+    def _make_abort_receiver(self, status=KVPoll.Bootstrapping):
+        class FakeKVManager:
+            def __init__(self, status):
+                self.status = status
+                self.failures = []
+                self.statuses = []
+
+            def check_status(self, bootstrap_room):
+                if self.status is None:
+                    raise KeyError(bootstrap_room)
+                return self.status
+
+            def record_failure(self, bootstrap_room, reason):
+                self.failures.append((bootstrap_room, reason))
+
+            def update_status(self, bootstrap_room, status):
+                self.statuses.append((bootstrap_room, status))
+
+        class FakeLock:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, traceback):
+                return False
+
+        class FakeSocket:
+            def __init__(self):
+                self.messages = []
+
+            def send_multipart(self, msg):
+                self.messages.append(msg)
+
+        fake_socket = FakeSocket()
+        receiver = MooncakeKVReceiver.__new__(MooncakeKVReceiver)
+        receiver.bootstrap_room = 17
+        receiver.bootstrap_infos = [
+            {"rank_ip": "127.0.0.1", "rank_port": 12345},
+            {"rank_ip": "127.0.0.2", "rank_port": 12346},
+        ]
+        receiver.kv_mgr = FakeKVManager(status)
+        receiver.conclude_state = None
+        receiver._connect_to_bootstrap_server = lambda bootstrap_info: (
+            fake_socket,
+            FakeLock(),
+        )
+        return receiver, fake_socket
+
+    def test_mooncake_receiver_abort_notifies_prefill_status_before_metadata(self):
+        receiver, fake_socket = self._make_abort_receiver(KVPoll.Bootstrapping)
+        receiver.abort("decode aborted before metadata")
+
+        self.assertEqual(
+            receiver.kv_mgr.failures, [(17, "decode aborted before metadata")]
+        )
+        self.assertEqual(receiver.kv_mgr.statuses, [(17, KVPoll.Failed)])
+        self.assertEqual(receiver.conclude_state, KVPoll.Failed)
+        self.assertEqual(len(fake_socket.messages), 2)
+        self.assertTrue(
+            all(
+                msg[0] == MooncakeKVManager.DECODE_STATUS_HEADER
+                for msg in fake_socket.messages
+            )
+        )
+        self.assertTrue(all(msg[1] == b"17" for msg in fake_socket.messages))
+        self.assertTrue(
+            all(
+                msg[2] == str(KVPoll.Failed).encode("ascii")
+                for msg in fake_socket.messages
+            )
+        )
+        self.assertTrue(
+            all(
+                msg[3] == b"decode aborted before metadata"
+                for msg in fake_socket.messages
+            )
+        )
+
+    def test_mooncake_receiver_abort_does_not_notify_prefill_after_metadata(self):
+        receiver, fake_socket = self._make_abort_receiver(KVPoll.WaitingForInput)
+        receiver.abort("stream client disconnected")
+
+        self.assertEqual(receiver.kv_mgr.failures, [(17, "stream client disconnected")])
+        self.assertEqual(receiver.kv_mgr.statuses, [(17, KVPoll.Failed)])
+        self.assertEqual(receiver.conclude_state, KVPoll.Failed)
+        self.assertEqual(fake_socket.messages, [])
+
+    def test_mooncake_receiver_abort_does_not_resurrect_cleared_room(self):
+        receiver, fake_socket = self._make_abort_receiver(None)
+        receiver.abort("late abort after clear")
+
+        self.assertEqual(receiver.kv_mgr.failures, [])
+        self.assertEqual(receiver.kv_mgr.statuses, [])
+        self.assertEqual(receiver.conclude_state, KVPoll.Failed)
+        self.assertEqual(fake_socket.messages, [])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -166,6 +166,7 @@ class TestHiSparseUnit(unittest.TestCase):
         self.coordinator.lru_slots[:] = self.coordinator._lru_init.view(1, 1, -1)
         self.coordinator.ack_staging_queue.clear()
         self.coordinator._has_pending_backup = False
+        self.coordinator._pending_draft_extend_backup = None
         for i in range(len(self.coordinator._skip_first_backup)):
             self.coordinator._skip_first_backup[i] = False
 
@@ -421,6 +422,62 @@ class TestHiSparseUnit(unittest.TestCase):
         self._cleanup_req(req, kv_loc, logical_only=True)
         self._assert_sizes_restored(initial, "long_seq")
 
+    def test_map_last_loc_records_newest_token_for_multistep_swap(self):
+        """Multi-step verify can resolve the newest-token extra-page slot."""
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE + self.page_size
+        req = _make_req("newest-token-metadata", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len)
+        self.coordinator.alloc_device_buffer(req)
+
+        req_idx = req.req_pool_idx
+        req_pool_indices = torch.tensor([req_idx], dtype=torch.int64, device="cuda")
+        seq_lens = torch.tensor([fill_len], dtype=torch.int64, device="cuda")
+        seq_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
+
+        self.coordinator.map_last_loc_to_buffer(
+            seq_lens=seq_lens,
+            out_cache_loc=kv_loc[-1:],
+            req_pool_indices=req_pool_indices,
+            seq_lens_cpu=seq_lens_cpu,
+        )
+
+        newest_slot = self.coordinator.req_to_device_buffer[req_idx, DEVICE_BUFFER_SIZE]
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, DEVICE_BUFFER_SIZE
+                ]
+                == fill_len - 1
+            )
+        )
+        self.assertEqual(
+            int(
+                self.allocator.full_to_hisparse_device_index_mapping[kv_loc[-1]].item()
+            ),
+            int(newest_slot.item()),
+        )
+
+        topk = torch.full((1, 4, TOP_K), -1, dtype=torch.int32, device="cuda")
+        topk[0, 0, 0] = fill_len - 1
+        self.coordinator.num_real_reqs[0] = 1
+        locs = self.coordinator.swap_in_selected_pages(
+            req_pool_indices=req_pool_indices,
+            compressed_seq_lens=torch.full(
+                (4,), fill_len, dtype=torch.int32, device="cuda"
+            ),
+            top_k_result=topk,
+            layer_id=0,
+            token_position_space="full",
+            num_steps=4,
+        )
+        self.assertEqual(int(locs[0, 0, 0].item()), int(newest_slot.item()))
+
+        self._cleanup_req(req, kv_loc)
+        self._assert_sizes_restored(initial, "newest_token_metadata")
+
     # ==================================================================
     # Test: Kernel LRU replacement across multiple decode steps
     # ==================================================================
@@ -645,6 +702,364 @@ class TestHiSparseUnit(unittest.TestCase):
             self._cleanup_req(req, kv_locs[i], logical_only=is_long)
 
         self._assert_sizes_restored(initial, "batch_multiple")
+
+    # ==================================================================
+    # Test: HiSparse MTP draft slots
+    # ==================================================================
+    def test_draft_slots_use_extra_page_after_newest_slot(self):
+        """Uniform draft slots start after the newest-token slot."""
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE
+        draft_num = 3
+        req = _make_req("draft-slots-uniform", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len)
+        self.coordinator.alloc_device_buffer(req)
+
+        req_idx = req.req_pool_idx
+        extra_start = DEVICE_BUFFER_SIZE + 1
+        req_pool_indices = torch.tensor([req_idx], dtype=torch.int64, device="cuda")
+        start_positions_cpu = torch.tensor([DEVICE_BUFFER_SIZE], dtype=torch.int64)
+
+        hot_tokens_before = self.coordinator.req_device_buffer_tokens[
+            :, req_idx, :DEVICE_BUFFER_SIZE
+        ].clone()
+        newest_token_sentinel = torch.full(
+            (LAYER_NUM,), 777, dtype=torch.int32, device="cuda"
+        )
+        self.coordinator.req_device_buffer_tokens[:, req_idx, DEVICE_BUFFER_SIZE] = (
+            newest_token_sentinel
+        )
+
+        device_slots = self.coordinator.get_draft_device_slots(
+            req_pool_indices,
+            draft_num,
+            start_positions_cpu,
+        )
+
+        expected_slots = self.coordinator.req_to_device_buffer[
+            req_idx, extra_start : extra_start + draft_num
+        ]
+        expected_token_positions = torch.arange(
+            DEVICE_BUFFER_SIZE,
+            DEVICE_BUFFER_SIZE + draft_num,
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+        self.assertTrue(torch.equal(device_slots, expected_slots))
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, :DEVICE_BUFFER_SIZE
+                ],
+                hot_tokens_before,
+            ),
+            "Draft slots must not rewrite hot-buffer token metadata",
+        )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, DEVICE_BUFFER_SIZE
+                ],
+                newest_token_sentinel,
+            ),
+            "Draft slots must not overwrite the newest-token slot",
+        )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, extra_start : extra_start + draft_num
+                ],
+                expected_token_positions.unsqueeze(0).expand(LAYER_NUM, -1),
+            )
+        )
+
+        self._cleanup_req(req, kv_loc)
+        self._assert_sizes_restored(initial, "draft_slots_uniform")
+
+    def test_draft_slots_variable_respect_per_request_counts(self):
+        """Variable draft slots only populate each request's actual token count."""
+        initial = self._get_initial_sizes()
+        reqs = [
+            _make_req("draft-slots-variable-0"),
+            _make_req("draft-slots-variable-1"),
+        ]
+        for req in reqs:
+            self._alloc_req_slot(req)
+
+        req_pool_indices = torch.tensor(
+            [req.req_pool_idx for req in reqs], dtype=torch.int64, device="cuda"
+        )
+        tokens_per_req_cpu = torch.tensor([1, 3], dtype=torch.int64)
+        start_positions_cpu = torch.tensor(
+            [DEVICE_BUFFER_SIZE, DEVICE_BUFFER_SIZE], dtype=torch.int64
+        )
+        extra_start = DEVICE_BUFFER_SIZE + 1
+
+        device_slots = self.coordinator.get_draft_device_slots_variable(
+            req_pool_indices,
+            tokens_per_req_cpu,
+            start_positions_cpu,
+        )
+
+        expected_slots = torch.cat(
+            [
+                self.coordinator.req_to_device_buffer[
+                    reqs[0].req_pool_idx, extra_start : extra_start + 1
+                ],
+                self.coordinator.req_to_device_buffer[
+                    reqs[1].req_pool_idx, extra_start : extra_start + 3
+                ],
+            ]
+        )
+        self.assertTrue(torch.equal(device_slots, expected_slots))
+
+        req0_expected = torch.tensor(
+            [DEVICE_BUFFER_SIZE, -1, -1], dtype=torch.int32, device="cuda"
+        )
+        req1_expected = torch.arange(
+            DEVICE_BUFFER_SIZE,
+            DEVICE_BUFFER_SIZE + 3,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, reqs[0].req_pool_idx, extra_start : extra_start + 3
+                ],
+                req0_expected.unsqueeze(0).expand(LAYER_NUM, -1),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, reqs[1].req_pool_idx, extra_start : extra_start + 3
+                ],
+                req1_expected.unsqueeze(0).expand(LAYER_NUM, -1),
+            )
+        )
+
+        for req in reqs:
+            self.coordinator.request_finished(req)
+            self._free_req_slot(req)
+        self._assert_sizes_restored(initial, "draft_slots_variable")
+
+    def test_finalize_accepted_tokens_remaps_newest_and_clears_rejected(self):
+        """Accepted MTP tokens move the last accepted KV to newest slot."""
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE
+        draft_num = 4
+        req = _make_req("finalize-accepted", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len)
+        self.coordinator.alloc_device_buffer(req)
+
+        req_idx = req.req_pool_idx
+        req_pool_indices = torch.tensor([req_idx], dtype=torch.int64, device="cuda")
+        start_positions_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        draft_device_slots = self.coordinator.get_draft_device_slots(
+            req_pool_indices,
+            draft_num,
+            start_positions_cpu,
+        )
+
+        device = self.allocator.device
+        prefix_lens = torch.tensor([fill_len], dtype=torch.int64, device=device)
+        prefix_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        seq_lens = torch.tensor(
+            [fill_len + draft_num], dtype=torch.int64, device=device
+        )
+        seq_lens_cpu = torch.tensor([fill_len + draft_num], dtype=torch.int64)
+        last_loc = kv_loc[-1:].to(device=device)
+        draft_cache_locs = self.allocator.alloc_extend_with_device_mapping(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            draft_num,
+            draft_device_slots,
+        )
+        self.req_to_token_pool.write(
+            (req_idx, slice(fill_len, fill_len + draft_num)), draft_cache_locs
+        )
+        req.kv_allocated_len = fill_len + draft_num
+        req.kv_committed_len = fill_len + draft_num
+
+        for lid in range(LAYER_NUM):
+            for i in range(draft_num):
+                self.device_pool.kv_buffer[lid][draft_device_slots[i]] = (
+                    self._kv_pattern(lid, fill_len + i)
+                )
+
+        accepted_cache_locs = draft_cache_locs[:2]
+        accepted_token_positions = torch.tensor(
+            [fill_len, fill_len + 1], dtype=torch.int64, device="cuda"
+        )
+        self.coordinator.finalize_accepted_tokens(
+            req_pool_indices=req_pool_indices,
+            accepted_cache_locs=accepted_cache_locs,
+            draft_cache_locs=draft_cache_locs,
+            num_correct_drafts=torch.tensor([1], dtype=torch.int64, device="cuda"),
+            num_correct_drafts_cpu=torch.tensor([1], dtype=torch.int64),
+            accepted_token_positions=accepted_token_positions,
+        )
+
+        mapping = self.allocator.full_to_hisparse_device_index_mapping
+        newest_slot = self.coordinator.req_to_device_buffer[req_idx, DEVICE_BUFFER_SIZE]
+
+        self.assertEqual(
+            int(mapping[accepted_cache_locs[0]].item()),
+            int(draft_device_slots[0].item()),
+        )
+        self.assertEqual(int(mapping[accepted_cache_locs[-1]].item()), int(newest_slot))
+        self.assertTrue(torch.all(mapping[draft_cache_locs[2:]] == 0))
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, DEVICE_BUFFER_SIZE
+                ]
+                == fill_len + 1
+            )
+        )
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_to_host_pool[req_idx, accepted_token_positions]
+                >= 0
+            )
+        )
+        for lid in range(LAYER_NUM):
+            expected = self._kv_pattern(lid, fill_len + 1)
+            actual = self.device_pool.kv_buffer[lid][newest_slot.long()]
+            self.assertTrue(
+                torch.allclose(
+                    actual.float(),
+                    torch.full_like(actual.float(), expected),
+                    atol=1e-2,
+                ),
+                f"Layer {lid}: newest slot was not updated from last accepted token",
+            )
+
+        self.coordinator.finish_pending_draft_extend_backup()
+        self.assertEqual(int(mapping[accepted_cache_locs[0]].item()), 0)
+        self.assertEqual(int(mapping[accepted_cache_locs[-1]].item()), int(newest_slot))
+
+        self.coordinator.request_finished(req)
+        self.allocator.free(torch.cat([kv_loc, draft_cache_locs]))
+        self._free_req_slot(req)
+        self._assert_sizes_restored(initial, "finalize_accepted_tokens")
+
+    def test_finalize_accepted_tokens_keeps_short_last_token_in_hot_slot(self):
+        """Short-context accepted tokens use the hot slot read by the fast path."""
+        initial = self._get_initial_sizes()
+        fill_len = self.page_size
+        draft_num = 4
+        req = _make_req("finalize-accepted-short", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len)
+        self.coordinator.alloc_device_buffer(req)
+
+        req_idx = req.req_pool_idx
+        req_pool_indices = torch.tensor([req_idx], dtype=torch.int64, device="cuda")
+        start_positions_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        draft_device_slots = self.coordinator.get_draft_device_slots(
+            req_pool_indices,
+            draft_num,
+            start_positions_cpu,
+        )
+
+        device = self.allocator.device
+        prefix_lens = torch.tensor([fill_len], dtype=torch.int64, device=device)
+        prefix_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        seq_lens = torch.tensor(
+            [fill_len + draft_num], dtype=torch.int64, device=device
+        )
+        seq_lens_cpu = torch.tensor([fill_len + draft_num], dtype=torch.int64)
+        last_loc = kv_loc[-1:].to(device=device)
+        draft_cache_locs = self.allocator.alloc_extend_with_device_mapping(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            draft_num,
+            draft_device_slots,
+        )
+        self.req_to_token_pool.write(
+            (req_idx, slice(fill_len, fill_len + draft_num)), draft_cache_locs
+        )
+        req.kv_allocated_len = fill_len + draft_num
+        req.kv_committed_len = fill_len + draft_num
+
+        accepted_cache_locs = draft_cache_locs[:2]
+        accepted_token_positions = torch.tensor(
+            [fill_len, fill_len + 1], dtype=torch.int64, device="cuda"
+        )
+        self.coordinator.finalize_accepted_tokens(
+            req_pool_indices=req_pool_indices,
+            accepted_cache_locs=accepted_cache_locs,
+            draft_cache_locs=draft_cache_locs,
+            num_correct_drafts=torch.tensor([1], dtype=torch.int64, device="cuda"),
+            num_correct_drafts_cpu=torch.tensor([1], dtype=torch.int64),
+            accepted_token_positions=accepted_token_positions,
+        )
+
+        mapping = self.allocator.full_to_hisparse_device_index_mapping
+        last_hot_slot = self.coordinator.req_to_device_buffer[req_idx, fill_len + 1]
+        extra_newest_slot = self.coordinator.req_to_device_buffer[
+            req_idx, DEVICE_BUFFER_SIZE
+        ]
+
+        self.assertEqual(
+            int(mapping[accepted_cache_locs[-1]].item()), int(last_hot_slot.item())
+        )
+        self.assertNotEqual(int(last_hot_slot.item()), int(extra_newest_slot.item()))
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_device_buffer_tokens[:, req_idx, fill_len + 1]
+                == fill_len + 1
+            )
+        )
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_device_buffer_token_locs[:, req_idx, fill_len + 1]
+                == last_hot_slot.to(torch.int32)
+            )
+        )
+        self.assertIsNone(self.coordinator._pending_draft_extend_backup)
+
+        self.coordinator.request_finished(req)
+        self.allocator.free(torch.cat([kv_loc, draft_cache_locs]))
+        self._free_req_slot(req)
+        self._assert_sizes_restored(initial, "finalize_accepted_tokens_short")
+
+    def test_draft_extend_cuda_graph_disabled_for_hisparse(self):
+        """Draft-extend graph replay is skipped when HiSparse owns KV mapping."""
+        from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
+            EAGLEDraftExtendCudaGraphRunner,
+        )
+
+        runner = EAGLEDraftExtendCudaGraphRunner.__new__(
+            EAGLEDraftExtendCudaGraphRunner
+        )
+        runner.eagle_worker = SimpleNamespace(
+            target_worker=SimpleNamespace(
+                model_runner=SimpleNamespace(hisparse_coordinator=object())
+            )
+        )
+        forward_batch = SimpleNamespace(
+            token_to_kv_pool=SimpleNamespace(
+                translate_loc_to_hisparse_device=lambda loc: loc
+            )
+        )
+
+        self.assertTrue(runner._uses_target_hisparse_coordinator(forward_batch))
+        self.assertFalse(runner.can_run(forward_batch))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -58,6 +58,27 @@ def _make_req(rid="test-req-0", origin_input_ids=None, output_ids=None):
     return req
 
 
+def test_next_decode_host_budget_counts_only_new_allocations():
+    from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+
+    coordinator = HiSparseCoordinator.__new__(HiSparseCoordinator)
+    coordinator.compress_ratio = 1
+    coordinator._skip_first_backup = [False]
+    coordinator._pending_draft_extend_backup = (
+        torch.arange(8, dtype=torch.int64),
+        torch.arange(8, dtype=torch.int64),
+        torch.arange(8, dtype=torch.int64),
+    )
+    req = _make_req("host-budget", list(range(4)))
+    req.req_pool_idx = 0
+    req.kv_committed_len = 4
+
+    assert (
+        coordinator.host_tokens_required_next_decode([req], speculative_token_budget=3)
+        == 4
+    )
+
+
 class TestHiSparseUnit(unittest.TestCase):
     """Test class that builds a minimal HiSparse component stack."""
 

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -646,6 +646,174 @@ class TestHiSparseUnit(unittest.TestCase):
         self._cleanup_req(req, kv_loc, logical_only=True)
         self._assert_sizes_restored(initial, "direct_path")
 
+    def test_retract_preserves_host_indices_and_resume_reuses_them(self):
+        """Retracted PD decode requests keep host KV and rebuild device state."""
+        from sglang.srt.disaggregation.decode import DecodePreallocQueue
+
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE + self.page_size
+        req = _make_req("retract-resume-req", list(range(fill_len)))
+        req.set_extend_input_len = lambda value: setattr(req, "extend_input_len", value)
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len, logical_only=True)
+        self._populate_host_pool(req, fill_len)
+        self.coordinator.admit_request_direct(req)
+
+        missing_pos = fill_len - 1
+        host_indices = self.coordinator.req_to_host_pool[
+            req.req_pool_idx, :fill_len
+        ].clone()
+        old_host_index = host_indices[missing_pos : missing_pos + 1]
+        self.coordinator.mem_pool_host.free(old_host_index)
+        self.coordinator.req_to_host_pool[req.req_pool_idx, missing_pos] = -1
+        newest_slot = self.coordinator.req_to_device_buffer[
+            req.req_pool_idx, DEVICE_BUFFER_SIZE
+        ]
+        self.allocator.full_to_hisparse_device_index_mapping[kv_loc[missing_pos]] = (
+            newest_slot
+        )
+        for lid in range(LAYER_NUM):
+            self.device_pool.kv_buffer[lid][newest_slot] = self._kv_pattern(
+                lid, missing_pos
+            )
+        host_available_after_admit = self.coordinator.mem_pool_host.available_size()
+
+        self.assertTrue(self.coordinator.retract_req(req))
+        self.assertTrue(hasattr(req, "hisparse_retracted_host_indices"))
+        self.assertEqual(
+            self.coordinator.mem_pool_host.available_size(),
+            host_available_after_admit - 1,
+        )
+        self.assertTrue(
+            torch.all(self.coordinator.req_to_host_pool[req.req_pool_idx] < 0)
+        )
+        self.assertEqual(
+            self.allocator.hisparse_attn_allocator.available_size(), initial[1]
+        )
+
+        self.allocator.logical_attn_allocator.free(kv_loc)
+        self._free_req_slot(req)
+        req.kv_allocated_len = 0
+        req.kv_committed_len = 0
+
+        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+        queue.req_to_token_pool = self.req_to_token_pool
+        queue.token_to_kv_pool_allocator = self.allocator
+        queue.num_reserved_decode_tokens = 1
+        queue.tree_cache = SimpleNamespace(
+            evictable_size=lambda: 0,
+            protected_size=lambda: 0,
+        )
+        queue.scheduler = SimpleNamespace(
+            enable_hisparse=True,
+            hisparse_coordinator=self.coordinator,
+            server_args=SimpleNamespace(
+                disaggregation_decode_enable_radix_cache=False,
+            ),
+        )
+
+        reused_host_indices = queue._pre_alloc(req)
+        self.assertFalse(hasattr(req, "hisparse_retracted_host_indices"))
+        self.assertTrue(
+            torch.equal(
+                reused_host_indices[:missing_pos].cpu(),
+                host_indices[:missing_pos].cpu(),
+            )
+        )
+        self.assertTrue(torch.all(reused_host_indices >= 0))
+        for lid in range(LAYER_NUM):
+            actual = self.coordinator.mem_pool_host.kv_buffer[lid][
+                reused_host_indices[missing_pos]
+            ]
+            expected = self._kv_pattern(lid, missing_pos)
+            self.assertTrue(
+                torch.allclose(
+                    actual.float(),
+                    torch.full_like(actual.float(), expected),
+                    atol=1e-2,
+                )
+            )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_to_host_pool[req.req_pool_idx, :fill_len].cpu(),
+                reused_host_indices.cpu(),
+            )
+        )
+        self.assertEqual(
+            self.coordinator.mem_pool_host.available_size(),
+            host_available_after_admit - 1,
+        )
+
+        self.coordinator.admit_request_direct(req)
+        resumed_kv_loc = self.req_to_token_pool.req_to_token[
+            req.req_pool_idx, :fill_len
+        ].clone()
+        self.coordinator.request_finished(req)
+        self.allocator.logical_attn_allocator.free(resumed_kv_loc)
+        self._free_req_slot(req)
+        self._assert_sizes_restored(initial, "retract_resume")
+
+    def test_release_retracted_req_frees_preserved_host_indices(self):
+        """Abort on the retracted queue releases preserved host KV."""
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE + self.page_size
+        req = _make_req("retract-abort-req", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len, logical_only=True)
+        self._populate_host_pool(req, fill_len)
+        self.coordinator.admit_request_direct(req)
+
+        self.assertTrue(self.coordinator.retract_req(req))
+        self.allocator.logical_attn_allocator.free(kv_loc)
+        self._free_req_slot(req)
+
+        self.coordinator.release_retracted_req(req)
+        self.assertFalse(hasattr(req, "hisparse_retracted_host_indices"))
+        self._assert_sizes_restored(initial, "retract_abort")
+
+    def test_retract_reports_failure_when_backup_host_alloc_fails(self):
+        """A failed retract backup is reported so the scheduler can abort one req."""
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE + self.page_size
+        req = _make_req("retract-backup-full-req", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len, logical_only=True)
+        self._populate_host_pool(req, fill_len)
+        self.coordinator.admit_request_direct(req)
+
+        missing_pos = fill_len - 1
+        old_host_index = self.coordinator.req_to_host_pool[
+            req.req_pool_idx, missing_pos : missing_pos + 1
+        ].clone()
+        self.coordinator.mem_pool_host.free(old_host_index)
+        self.coordinator.req_to_host_pool[req.req_pool_idx, missing_pos] = -1
+        filler = self.coordinator.mem_pool_host.alloc(
+            self.coordinator.mem_pool_host.available_size()
+        )
+        self.assertIsNotNone(filler, "Host filler alloc failed")
+
+        newest_slot = self.coordinator.req_to_device_buffer[
+            req.req_pool_idx, DEVICE_BUFFER_SIZE
+        ]
+        self.allocator.full_to_hisparse_device_index_mapping[kv_loc[missing_pos]] = (
+            newest_slot
+        )
+
+        self.assertFalse(self.coordinator.retract_req(req))
+        self.assertFalse(hasattr(req, "hisparse_retracted_host_indices"))
+        self.assertFalse(
+            torch.all(self.coordinator.req_to_host_pool[req.req_pool_idx] < 0)
+        )
+
+        self.coordinator.request_finished(req)
+        self.allocator.logical_attn_allocator.free(kv_loc)
+        self._free_req_slot(req)
+        self.coordinator.mem_pool_host.free(filler)
+        self._assert_sizes_restored(initial, "retract_backup_full")
+
     # ==================================================================
     # Test: Batch multiple requests
     # ==================================================================
@@ -846,6 +1014,66 @@ class TestHiSparseUnit(unittest.TestCase):
             self.coordinator.request_finished(req)
             self._free_req_slot(req)
         self._assert_sizes_restored(initial, "draft_slots_variable")
+
+    def test_draft_logical_alloc_allows_in_page_extend_with_no_free_pages(self):
+        """Draft logical allocation can extend inside an existing page at 0 free pages."""
+        if self.page_size == 1:
+            self.skipTest("In-page paged extension requires page_size > 1.")
+
+        initial = self._get_initial_sizes()
+        device = self.allocator.device
+        fill_len = self.page_size * 2 + 1
+        draft_num = 4
+
+        kv_loc = self.allocator.alloc_extend(
+            prefix_lens=torch.tensor([0], dtype=torch.int64, device=device),
+            prefix_lens_cpu=torch.tensor([0], dtype=torch.int64),
+            seq_lens=torch.tensor([fill_len], dtype=torch.int64, device=device),
+            seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
+            last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
+            extend_num_tokens=fill_len,
+        )
+        self.assertIsNotNone(kv_loc)
+
+        filler = self.allocator.logical_attn_allocator.alloc(
+            self.allocator.logical_attn_allocator.available_size()
+        )
+        self.assertIsNotNone(filler)
+        self.assertEqual(self.allocator.logical_attn_allocator.available_size(), 0)
+
+        prefix_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        seq_lens_cpu = torch.tensor([fill_len + draft_num], dtype=torch.int64)
+        device_slots = torch.arange(1, draft_num + 1, dtype=torch.int64, device=device)
+
+        draft_cache_locs = self.allocator.alloc_extend_with_device_mapping(
+            prefix_lens=prefix_lens_cpu.to(device=device),
+            prefix_lens_cpu=prefix_lens_cpu,
+            seq_lens=seq_lens_cpu.to(device=device),
+            seq_lens_cpu=seq_lens_cpu,
+            last_loc=kv_loc[-1:],
+            extend_num_tokens=draft_num,
+            device_slots=device_slots,
+        )
+
+        self.assertEqual(len(draft_cache_locs), draft_num)
+        self.assertEqual(self.allocator.logical_attn_allocator.available_size(), 0)
+        self.assertTrue(
+            torch.equal(
+                draft_cache_locs,
+                kv_loc[-1] + torch.arange(1, draft_num + 1, device=device),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                self.allocator.full_to_hisparse_device_index_mapping[draft_cache_locs],
+                device_slots,
+            )
+        )
+
+        self.allocator.full_to_hisparse_device_index_mapping[draft_cache_locs] = 0
+        self.allocator.free(torch.cat([kv_loc, draft_cache_locs]))
+        self.allocator.logical_attn_allocator.free(filler)
+        self._assert_sizes_restored(initial, "draft_logical_in_page_extend")
 
     def test_finalize_accepted_tokens_remaps_newest_and_clears_rejected(self):
         """Accepted MTP tokens move the last accepted KV to newest slot."""

--- a/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
+++ b/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
@@ -184,6 +184,57 @@ class TestDecodePreallocQueuePriority(unittest.TestCase):
         )
         self.assertEqual(failed, [])
 
+    def test_hisparse_host_budget_blocks_prealloc_before_host_alloc(self):
+        decode_req = self._new_decode_req("blocked", 1)
+        queue = self._new_queue([decode_req])
+        queue.num_reserved_decode_tokens = 2
+        queue.scheduler.enable_hisparse = True
+        queue.scheduler.hisparse_coordinator = SimpleNamespace(
+            padded_buffer_size=1,
+            compressed_host_len=lambda full_len: full_len,
+            host_decode_reserve_len=lambda full_len, num_decode_tokens: num_decode_tokens,
+            mem_pool_host=SimpleNamespace(available_size=MagicMock(return_value=4)),
+        )
+        queue.token_to_kv_pool_allocator.logical_attn_allocator.available_size.return_value = (
+            100
+        )
+        queue.token_to_kv_pool_allocator.hisparse_attn_allocator.available_size.return_value = (
+            100
+        )
+
+        preallocated, failed = queue.pop_preallocated()
+
+        self.assertEqual(preallocated, [])
+        self.assertEqual(failed, [])
+        queue._pre_alloc.assert_not_called()
+
+    def test_hisparse_host_budget_reserves_outputs_to_completion(self):
+        decode_req = self._new_decode_req("blocked-by-output-reserve", 1)
+        running_req = self._new_decode_req("running", 2).req
+        running_req.kv_committed_len = len(running_req.origin_input_ids)
+        queue = self._new_queue([decode_req])
+        queue.num_reserved_decode_tokens = 2
+        queue.scheduler.running_batch.reqs = [running_req]
+        queue.scheduler.enable_hisparse = True
+        queue.scheduler.hisparse_coordinator = SimpleNamespace(
+            padded_buffer_size=1,
+            compressed_host_len=lambda full_len: full_len,
+            host_decode_reserve_len=lambda full_len, num_decode_tokens: num_decode_tokens,
+            mem_pool_host=SimpleNamespace(available_size=MagicMock(return_value=15)),
+        )
+        queue.token_to_kv_pool_allocator.logical_attn_allocator.available_size.return_value = (
+            100
+        )
+        queue.token_to_kv_pool_allocator.hisparse_attn_allocator.available_size.return_value = (
+            100
+        )
+
+        preallocated, failed = queue.pop_preallocated()
+
+        self.assertEqual(preallocated, [])
+        self.assertEqual(failed, [])
+        queue._pre_alloc.assert_not_called()
+
     def test_failed_request_indices_stay_valid_after_priority_sort(self):
         failed_low = self._new_decode_req("failed-low", 1, failed=True)
         healthy_high = self._new_decode_req("healthy-high", 10)

--- a/test/registered/unit/managers/test_scheduler_output_processor.py
+++ b/test/registered/unit/managers/test_scheduler_output_processor.py
@@ -1,0 +1,112 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler_output_processor_mixin import (
+    SchedulerOutputProcessorMixin,
+)
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+class _FakeMambaPool:
+    def __init__(self):
+        self.freed_indices = []
+
+    def free(self, indices):
+        self.freed_indices.append(indices.clone())
+
+
+class TestSchedulerOutputProcessorFinishedReq(unittest.TestCase):
+    def _new_scheduler(self, tree_cache):
+        scheduler = SimpleNamespace()
+        scheduler.server_args = SimpleNamespace(
+            disaggregation_decode_enable_offload_kvcache=False
+        )
+        scheduler.tree_cache = tree_cache
+        scheduler.enable_hisparse = False
+        scheduler.maybe_collect_routed_experts = MagicMock()
+        scheduler.maybe_collect_indexer_topk = MagicMock()
+        scheduler.maybe_collect_customized_info = MagicMock()
+        return scheduler
+
+    def _new_finished_req(self, *, req_pool_idx, mamba_pool_idx=None):
+        req = SimpleNamespace()
+        req.rid = "finished-req"
+        req.req_pool_idx = req_pool_idx
+        req.mamba_pool_idx = mamba_pool_idx
+        req.multimodal_inputs = None
+        req.session = None
+        req.kv_committed_freed = False
+        req.kv_overallocated_freed = False
+        req.time_stats = SimpleNamespace(set_completion_time=MagicMock())
+        req.finished = MagicMock(return_value=True)
+        return req
+
+    def test_finished_req_without_req_pool_idx_releases_mamba_slot(self):
+        mamba_pool = _FakeMambaPool()
+        tree_cache = SimpleNamespace(
+            supports_mamba=MagicMock(return_value=True),
+            req_to_token_pool=SimpleNamespace(mamba_pool=mamba_pool),
+        )
+        scheduler = self._new_scheduler(tree_cache)
+        req = self._new_finished_req(
+            req_pool_idx=None, mamba_pool_idx=torch.tensor(7, dtype=torch.int64)
+        )
+
+        SchedulerOutputProcessorMixin._handle_finished_req(
+            scheduler, req, 0, logits_output=None
+        )
+
+        self.assertIsNone(req.mamba_pool_idx)
+        self.assertEqual(len(mamba_pool.freed_indices), 1)
+        torch.testing.assert_close(
+            mamba_pool.freed_indices[0], torch.tensor([7], dtype=torch.int64)
+        )
+        tree_cache.supports_mamba.assert_called_once()
+        req.time_stats.set_completion_time.assert_called_once()
+
+    def test_finished_req_without_any_pool_idx_keeps_duplicate_kv_release_guard(self):
+        tree_cache = SimpleNamespace(supports_mamba=MagicMock(return_value=True))
+        scheduler = self._new_scheduler(tree_cache)
+        req = self._new_finished_req(req_pool_idx=None, mamba_pool_idx=None)
+
+        with patch(
+            "sglang.srt.managers.scheduler_output_processor_mixin.release_kv_cache"
+        ) as release_kv_cache:
+            SchedulerOutputProcessorMixin._handle_finished_req(
+                scheduler, req, 0, logits_output=None
+            )
+
+        release_kv_cache.assert_not_called()
+        tree_cache.supports_mamba.assert_not_called()
+        req.time_stats.set_completion_time.assert_called_once()
+
+    def test_finished_req_with_req_pool_idx_uses_existing_release_path(self):
+        tree_cache = MagicMock()
+        scheduler = self._new_scheduler(tree_cache)
+        scheduler.enable_hisparse = True
+        scheduler.hisparse_coordinator = SimpleNamespace(request_finished=MagicMock())
+        req = self._new_finished_req(req_pool_idx=3)
+
+        with patch(
+            "sglang.srt.managers.scheduler_output_processor_mixin.release_kv_cache"
+        ) as release_kv_cache:
+            SchedulerOutputProcessorMixin._handle_finished_req(
+                scheduler, req, 0, logits_output=None
+            )
+
+        scheduler.hisparse_coordinator.request_finished.assert_called_once_with(req)
+        release_kv_cache.assert_called_once_with(req, tree_cache)
+        req.time_stats.set_completion_time.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
@@ -516,6 +517,49 @@ class TestNgramExternalSamArgs(CustomTestCase):
         with self.assertRaises(ValueError) as context:
             handle_speculative_decoding(args)
         self.assertIn("external-corpus-max-tokens", str(context.exception))
+
+
+class TestHiSparseMTPServerArgs(unittest.TestCase):
+    def _make_hisparse_mtp_args(self, **overrides) -> ServerArgs:
+        args = ServerArgs(model_path="dummy")
+        args.served_model_name = "dummy"
+        args.enable_hisparse = True
+        args.disable_radix_cache = True
+        args.speculative_algorithm = "EAGLE"
+        args.speculative_num_draft_tokens = 4
+        args.speculative_eagle_topk = 1
+        args.enable_mixed_chunk = False
+        args.hisparse_config = '{"top_k": 128}'
+        args.kv_cache_dtype = "bfloat16"
+        args.nsa_prefill_backend = "flashmla_sparse"
+        args.nsa_decode_backend = "flashmla_sparse"
+        args.page_size = 1
+        args.chunked_prefill_size = -1
+        args.enable_grpc = False
+        args.grpc_port = None
+        args.model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(
+                architectures=["GlmMoeDsaForCausalLM"],
+                index_topk=128,
+            )
+        )
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
+    def test_missing_hisparse_page_size_uses_default_capacity(self):
+        args = self._make_hisparse_mtp_args()
+
+        args.check_server_args()
+
+    def test_explicit_small_hisparse_page_size_still_rejects_draft_tokens(self):
+        args = self._make_hisparse_mtp_args(hisparse_config='{"page_size": 4}')
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "hiSparse extra page capacity \\(3 slots\\) is insufficient",
+        ):
+            args.check_server_args()
 
 
 class TestDeepEPWaterfillArgs(CustomTestCase):


### PR DESCRIPTION
## Summary

Cherry-pick the HiSparse MTP/speculative decoding without H2D follow-up changes onto `pr2ybyang/hisparse-mtp-without-h2d`.

This PR brings in 5 commits from `fea/hisparse-mtp-without-h2d` after `8d5ed330cc99d5b37325a9dd175f4cb8554de3f3`.

## Changes

- Add HiSparse MTP/speculative decoding support with extra-page draft zones.
- Fix HiSparse MTP draft KV mapping across draft/verify paths.
- Fix PD decode retract behavior for HiSparse by avoiding the unsupported `get_cpu_copy()` path.
- Fix HiSparse host-pool budgeting and Mooncake cleanup paths.
- Release leftover Mamba slots when finished requests no longer have `req_pool_idx`.

## Cherry-picked Commits

- `5917d1f25` -> `[Feature] Support MTP/speculative decoding with hiSparse extra page draft zone`
- `491c1e7fd` -> `fix: 修复 HiSparse MTP draft KV 映射`
- `885400408` -> `fix: 修复 PD decode 节点 HiSparse retract 时 get_cpu_copy 未实现导致崩溃`
- `ba4db93b0` -> `fix: 修复 HiSparse host pool 预算和 Mooncake 收尾`
- `5adb89d4f` -> `fix: 清理 req_pool_idx 为空时的 Mamba cache`

## Conflict Resolution Notes

Two conflicts were resolved during cherry-pick:

- `python/sglang/srt/managers/schedule_batch.py`
- Kept the new `hisparse_coordinator` propagation into `ModelWorkerBatch`.
- `python/sglang/srt/model_executor/forward_batch_info.py`
- Preserved the target branch's existing `return_hidden_states_before_norm=batch.return_hidden_states_before_norm` behavior.
- Added `hisparse_coordinator=batch.hisparse_coordinator`.

## Testing

- `git diff --check HEAD~5..HEAD`
- `python -m py_compile` on changed Python files
- Pre-commit hooks passed during cherry-pick continuation

Known local validation limitation:

- `pytest test/registered/unit/disaggregation/test_mooncake_hisparse.py --tb=short` was blocked during collection by a local dependency compatibility issue between `transformers==5.6.0` and `kernels==0.15.2`:
- `ValueError: Either a revision or a version must be specified.`