### PR TITLE
hisparse mtp without h2d based on glm52

### DIFF
--- a/python/sglang/jit_kernel/csrc/hisparse.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse.cuh
@@ -125,23 +125,85 @@ __device__ __forceinline__ int warp_inclusive_scan(int* s_data, int lane_id, int
   return accumulator;
 }
 
+template <int HOT_BUFFER_SIZE, bool IsDsv4Layout>
+__device__ __forceinline__ bool try_get_static_device_loc(
+    int32_t token_idx,
+    const int32_t* __restrict__ req_device_buffer_locs,
+    int64_t page_size,
+    int32_t* __restrict__ out_loc) {
+  if constexpr (IsDsv4Layout) {
+    return false;
+  } else {
+    if (token_idx < 0 || token_idx >= HOT_BUFFER_SIZE) {
+      return false;
+    }
+    const int32_t loc = req_device_buffer_locs[token_idx];
+    if (loc < 0) {
+      return false;
+    }
+    *out_loc = loc;
+    return true;
+  }
+}
+
+template <int HOT_BUFFER_SIZE, bool IsDsv4Layout>
+__device__ __forceinline__ bool try_get_extra_page_device_loc(
+    int32_t token_idx,
+    int64_t seq_len,
+    int64_t step,
+    int64_t num_steps,
+    const int32_t* __restrict__ req_device_buffer_tokens,
+    const int32_t* __restrict__ req_device_buffer_locs,
+    int64_t page_size,
+    int32_t* __restrict__ out_loc) {
+  int64_t slot = -1;
+  if constexpr (IsDsv4Layout) {
+    if (token_idx == seq_len - 1) {
+      slot = HOT_BUFFER_SIZE;
+    }
+  } else if (num_steps > 1) {
+    for (int64_t candidate_slot = HOT_BUFFER_SIZE; candidate_slot < HOT_BUFFER_SIZE + page_size; candidate_slot++) {
+      if (req_device_buffer_tokens[candidate_slot] == token_idx) {
+        slot = candidate_slot;
+        break;
+      }
+    }
+  } else if (token_idx == seq_len - 1) {
+    slot = HOT_BUFFER_SIZE;
+  }
+
+  if (slot < HOT_BUFFER_SIZE || slot >= HOT_BUFFER_SIZE + page_size) {
+    return false;
+  }
+  const int32_t loc = req_device_buffer_locs[slot];
+  if (loc < 0) {
+    return false;
+  }
+  *out_loc = loc;
+  return true;
+}
+
 // Shared memory size calculation for dynamic allocation.
 // Layout: int32_t region (4-byte aligned) followed by int16_t region (2-byte aligned).
 template <int NUM_TOP_K, int HOT_BUFFER_SIZE>
 struct SmemLayout {
   static constexpr int HASH_SIZE = NUM_TOP_K * 2;
   static constexpr int NUM_BUFFER_CHUNKS = (HOT_BUFFER_SIZE + WARP_SIZE - 1) / WARP_SIZE;
-  // int32_t region: top_k_tokens + chunk_offset + evict_chunk_offset + hash_keys + total_hits + newest_hit
-  static constexpr int TOTAL_INT32 = NUM_TOP_K + (NUM_BUFFER_CHUNKS + 1) + (NUM_BUFFER_CHUNKS + 1) + HASH_SIZE + 2;
+  // int32_t region: top_k_tokens + chunk offsets + evict offsets + hash keys + scalar counters.
+  static constexpr int TOTAL_INT32 = NUM_TOP_K + (NUM_BUFFER_CHUNKS + 1) + (NUM_BUFFER_CHUNKS + 1) + HASH_SIZE + 3;
   // int16_t region: lru_slots_out + hash_vals
   static constexpr int TOTAL_INT16 = HOT_BUFFER_SIZE + HASH_SIZE;
   static constexpr size_t BYTES = TOTAL_INT32 * sizeof(int32_t) + TOTAL_INT16 * sizeof(int16_t);
 };
 
-// Each block processes one request
+// Each block processes one request, looping over num_steps speculative steps.
 // req_pool_indices and seq_lens can each be int32_t or int64_t
 // Layout: [HOT_BUFFER_SIZE slots for LRU] + [page_size slots for newest token]
 // newest_slot is at HOT_BUFFER_SIZE (first position of extra page)
+//
+// Multi-step: top_k_tokens and top_k_device_locs are [num_reqs, num_steps, NUM_TOP_K]
+// (req-major). seq_lens is [num_reqs * num_steps] flat req-major. LRU state is
+// maintained across steps within each block for cross-step cache reuse.
 //
 // IsDsv4Layout selects the miss-copy addressing:
 //   false -> generic byte-stride: device + host both linear, stride = item_size_bytes
@@ -174,15 +236,14 @@ __global__ void load_cache_to_device_buffer_kernel(
     int64_t top_k_tokens_stride,
     int64_t top_k_device_locs_stride,
     int64_t page_size,
-    int64_t item_size_bytes) {
+    int64_t item_size_bytes,
+    int64_t num_steps) {
   static_assert(!IsDsv4Layout || IsMLA, "DSv4 page-padded layout is K-only (MLA).");
-  // todo hisparse: support page wise sparsity
   constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
   constexpr int NUM_TOKEN_CHUNKS = (NUM_TOP_K + WARP_SIZE - 1) / WARP_SIZE;
   constexpr int NUM_BUFFER_CHUNKS = (HOT_BUFFER_SIZE + WARP_SIZE - 1) / WARP_SIZE;
 
   const int bid = blockIdx.x;
-  // Early exit for padded blocks (CUDA graph pads batch to a captured size)
   if (bid >= num_real_reqs[0]) return;
 
   const int tid = threadIdx.x;
@@ -191,269 +252,299 @@ __global__ void load_cache_to_device_buffer_kernel(
   const unsigned int lanes_before = ((unsigned int)1 << lane_id) - 1;
 
   const int64_t rid = req_pool_indices[bid];
-  const int64_t seq_len = seq_lens[bid];
 
-  // Calculate offsets for this request
-  const int32_t* req_top_k_tokens = top_k_tokens + bid * top_k_tokens_stride;
-  int32_t* req_top_k_device_locs = top_k_device_locs + bid * top_k_device_locs_stride;
-
+  // Per-request pointers (invariant across steps)
   const int64_t buffer_offset = rid * buffer_stride_0;
   int32_t* req_device_buffer_tokens = device_buffer_tokens + buffer_offset;
   const int32_t* req_device_buffer_locs = device_buffer_locs + buffer_offset;
   const int64_t* req_host_cache_locs = host_cache_locs + rid * host_stride;
   int16_t* req_lru_slots = lru_slots + rid * lru_slot_stride_0;
 
-  // Fast path: short sequences have all tokens in the device buffer in order.
-  if (seq_len <= HOT_BUFFER_SIZE) {
-    const int count = (seq_len < NUM_TOP_K) ? static_cast<int>(seq_len) : NUM_TOP_K;
-    for (int i = tid; i < count; i += BLOCK_SIZE) {
-      int32_t token_pos = req_top_k_tokens[i];
-      if (token_pos >= 0) {
-        req_top_k_device_locs[i] = req_device_buffer_locs[token_pos];
-      }
-    }
-    return;
-  }
+  // Base pointers for this request's top_k data (steps are contiguous after)
+  const int32_t* req_top_k_tokens_base = top_k_tokens + bid * top_k_tokens_stride;
+  int32_t* req_top_k_device_locs_base = top_k_device_locs + bid * top_k_device_locs_stride;
 
-  // Dynamic shared memory layout: int32_t arrays first, then int16_t arrays.
+  // Shared memory layout (allocated once, reused across steps)
   extern __shared__ char smem_raw[];
   using Layout = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>;
   constexpr int HASH_SIZE = Layout::HASH_SIZE;
 
   int32_t* smem_i32 = reinterpret_cast<int32_t*>(smem_raw);
-  // Top-k token positions; reused as miss-token scratch in the copy phase
   int32_t* s_top_k_tokens = smem_i32;
-  // Prefix-sum offsets for hit counting and miss counting
   int32_t* s_chunk_offset = s_top_k_tokens + NUM_TOP_K;
-  // Prefix-sum offsets for evictable counting
   int32_t* s_evict_chunk_offset = s_chunk_offset + (NUM_BUFFER_CHUNKS + 1);
-  // Open-addressing hash table: top-k token_id -> top-k index (keys)
   int32_t* s_hash_keys = s_evict_chunk_offset + (NUM_BUFFER_CHUNKS + 1);
-  // Scalar counters
   int32_t& s_total_hits = s_hash_keys[HASH_SIZE];
   int32_t& s_newest_hit = s_hash_keys[HASH_SIZE + 1];
+  int32_t& s_total_misses = s_hash_keys[HASH_SIZE + 2];
 
   int16_t* smem_i16 = reinterpret_cast<int16_t*>(smem_i32 + Layout::TOTAL_INT32);
-  // Compacted slot ordering: [hits fwd->  ...  <-evictables bwd]
   int16_t* s_lru_slots_out = smem_i16;
-  // Open-addressing hash table: top-k token_id -> top-k index (values)
   int16_t* s_hash_vals = s_lru_slots_out + HOT_BUFFER_SIZE;
 
-  // Initialize shared memory: counters, hash table, prefix-sum offsets.
-  if (tid == 0) {
-    s_total_hits = 0;
-    s_newest_hit = 0;
-  }
-  for (int i = tid; i < HASH_SIZE; i += BLOCK_SIZE) {
-    s_hash_keys[i] = HASH_EMPTY;
-  }
-  for (int i = tid; i < NUM_BUFFER_CHUNKS + 1; i += BLOCK_SIZE) {
-    s_chunk_offset[i] = 0;
-    s_evict_chunk_offset[i] = 0;
-  }
-  __syncthreads();
+  for (int64_t step = 0; step < num_steps; step++) {
+    // Per-step pointers: [num_reqs, num_steps, NUM_TOP_K] req-major layout
+    const int32_t* step_top_k_tokens = req_top_k_tokens_base + step * NUM_TOP_K;
+    int32_t* step_top_k_device_locs = req_top_k_device_locs_base + step * NUM_TOP_K;
+    // seq_lens: [num_reqs * num_steps] flat req-major; index = bid * num_steps + step
+    const int64_t seq_len = static_cast<int64_t>(seq_lens[bid * num_steps + step]);
 
-  const int newest_slot = HOT_BUFFER_SIZE;
-  const int32_t newest_token = seq_len - 1;
-
-  // Insert top-k tokens into shared-memory hash table.
-  for (int i = tid; i < NUM_TOP_K; i += BLOCK_SIZE) {
-    int32_t token_idx = req_top_k_tokens[i];
-    if (token_idx == newest_token) {
-      // If topk includes the latest token, bind its canonical occurrence to newest_slot (at HOT_BUFFER_SIZE) and mark
-      // it as a hit. newest_slot is at the first position of the extra page, excluded from LRU tracking.
-      s_top_k_tokens[i] = TOKEN_HIT;
-      req_top_k_device_locs[i] = req_device_buffer_locs[newest_slot];
-      s_newest_hit = 1;
-    } else {
-      int slot = hash_slot(token_idx, HASH_SIZE);
-      while (true) {
-        int32_t old = atomicCAS(&s_hash_keys[slot], HASH_EMPTY, token_idx);
-        if (old == HASH_EMPTY || old == token_idx) {
-          s_hash_vals[slot] = static_cast<int16_t>(i);
-          break;
+    // Fast path: short sequences have all tokens in the device buffer in order.
+    if (seq_len <= HOT_BUFFER_SIZE) {
+      const int count = (seq_len < NUM_TOP_K) ? static_cast<int>(seq_len) : NUM_TOP_K;
+      for (int i = tid; i < count; i += BLOCK_SIZE) {
+        int32_t token_pos = step_top_k_tokens[i];
+        int32_t loc = -1;
+        if (try_get_static_device_loc<HOT_BUFFER_SIZE, IsDsv4Layout>(
+                token_pos, req_device_buffer_locs, page_size, &loc) ||
+            try_get_extra_page_device_loc<HOT_BUFFER_SIZE, IsDsv4Layout>(
+                token_pos,
+                seq_len,
+                step,
+                num_steps,
+                req_device_buffer_tokens,
+                req_device_buffer_locs,
+                page_size,
+                &loc)) {
+          step_top_k_device_locs[i] = loc;
         }
-        slot = (slot + 1) % HASH_SIZE;
       }
-      s_top_k_tokens[i] = token_idx;
-    }
-  }
-  __syncthreads();
-
-  constexpr int ITERATIONS_PER_WARP_BUFFER = (NUM_BUFFER_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
-  int total_hit_count = 0;
-  int total_evict_count = 0;
-  for (int iter = 0; iter < ITERATIONS_PER_WARP_BUFFER; iter++) {
-    int chunk_idx = warp_id + iter * NUM_WARPS;
-    bool has_valid_chunk = chunk_idx < NUM_BUFFER_CHUNKS;
-
-    const int slot_idx = chunk_idx * WARP_SIZE + lane_id;
-    const bool has_valid_slot = has_valid_chunk && (slot_idx < HOT_BUFFER_SIZE);
-    const int16_t buf_slot = has_valid_slot ? req_lru_slots[slot_idx] : -1;
-    int32_t my_buffer_token = (buf_slot >= 0) ? req_device_buffer_tokens[buf_slot] : -1;
-    int my_found_top_k_idx = -1;
-    if (my_buffer_token >= 0) {
-      int h = hash_slot(my_buffer_token, HASH_SIZE);
-      while (true) {
-        int32_t k = s_hash_keys[h];
-        if (k == my_buffer_token) {
-          my_found_top_k_idx = static_cast<int32_t>(s_hash_vals[h]);
-          break;
-        }
-        if (k == HASH_EMPTY) break;
-        h = (h + 1) % HASH_SIZE;
-      }
-    }
-    bool is_hit = my_found_top_k_idx >= 0;
-    bool is_evictable = has_valid_slot && !is_hit;
-
-    // Record hits
-    if (is_hit) {
-      s_top_k_tokens[my_found_top_k_idx] = TOKEN_HIT;
-      req_top_k_device_locs[my_found_top_k_idx] = req_device_buffer_locs[buf_slot];
+      continue;
     }
 
-    int local_hit_offset = 0;
-    int local_evict_offset = 0;
-    if (has_valid_chunk) {
-      const unsigned int hit_mask = __ballot_sync(0xFFFFFFFF, is_hit);
-      const unsigned int evict_mask = __ballot_sync(0xFFFFFFFF, is_evictable);
-      local_hit_offset = __popc(hit_mask & lanes_before);
-      local_evict_offset = __popc(evict_mask & lanes_before);
-      if (lane_id == 0) {
-        s_chunk_offset[chunk_idx + 1] = __popc(hit_mask);
-        s_evict_chunk_offset[chunk_idx + 1] = __popc(evict_mask);
-      }
+    // Initialize shared memory for this step
+    if (tid == 0) {
+      s_total_hits = 0;
+      s_newest_hit = 0;
+      s_total_misses = 0;
+    }
+    for (int i = tid; i < HASH_SIZE; i += BLOCK_SIZE) {
+      s_hash_keys[i] = HASH_EMPTY;
+    }
+    for (int i = tid; i < NUM_BUFFER_CHUNKS + 1; i += BLOCK_SIZE) {
+      s_chunk_offset[i] = 0;
+      s_evict_chunk_offset[i] = 0;
     }
     __syncthreads();
 
-    if (warp_id == 0) {
-      total_hit_count =
-          warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_hit_count);
-      total_evict_count =
-          warp_inclusive_scan(s_evict_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_evict_count);
-      if (tid == 0) {
-        s_total_hits = total_hit_count;
-      }
-    }
-    __syncthreads();
-
-    // Hits grow forward from index 0
-    if (is_hit) {
-      int hit_offset = s_chunk_offset[chunk_idx] + local_hit_offset;
-      s_lru_slots_out[hit_offset] = buf_slot;
-    }
-    // Evictables grow backward from HOT_BUFFER_SIZE - 1
-    if (is_evictable) {
-      int evict_offset = s_evict_chunk_offset[chunk_idx] + local_evict_offset;
-      s_lru_slots_out[HOT_BUFFER_SIZE - 1 - evict_offset] = buf_slot;
-    }
-  }
-  __syncthreads();
-
-  // Reset offsets for the miss counting phase (only NUM_TOKEN_CHUNKS + 1 entries needed).
-  for (int i = tid; i < NUM_TOKEN_CHUNKS + 1; i += BLOCK_SIZE) {
-    s_chunk_offset[i] = 0;
-  }
-  __syncthreads();
-
-  // Third pass to identify misses and their evictable slots
-  int total_misses = 0;
-  constexpr int ITERATIONS_PER_WARP_TOKEN = (NUM_TOKEN_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
-  for (int iter = 0; iter < ITERATIONS_PER_WARP_TOKEN; iter++) {
-    int chunk_idx = warp_id + iter * NUM_WARPS;
-    bool has_valid_chunk = chunk_idx < NUM_TOKEN_CHUNKS;
-
-    const int chunk_token_start = chunk_idx * WARP_SIZE;
-    const int my_token_idx = chunk_token_start + lane_id;
-    const bool has_valid_token = has_valid_chunk && (my_token_idx < NUM_TOP_K);
-
-    int32_t my_token = 0;
-    bool is_miss = false;
-    int local_miss_offset = 0;
-
-    if (has_valid_token) {
-      is_miss = s_top_k_tokens[my_token_idx] != TOKEN_HIT;
-      if (is_miss) {
-        my_token = s_top_k_tokens[my_token_idx];
-      }
-    }
-
-    if (has_valid_chunk) {
-      const unsigned int miss_mask = __ballot_sync(0xFFFFFFFF, is_miss);
-      local_miss_offset = __popc(miss_mask & lanes_before);
-      const int warp_miss_count = __popc(miss_mask);
-      if (lane_id == 0) {
-        s_chunk_offset[chunk_idx + 1] = warp_miss_count;
-      }
-    }
-    __syncthreads();
-
-    if (warp_id == 0) {
-      total_misses = warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_TOKEN_CHUNKS + 1, total_misses);
-    }
-    __syncthreads();
-
-    if (is_miss) {
-      int miss_offset = s_chunk_offset[chunk_idx] + local_miss_offset;
-      int16_t evict_slot = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_offset];
-      // Reuse s_top_k_tokens as miss scratch: miss_offset < my_token_idx always
-      // holds (hits are skipped), so compacted writes never overrun pending reads.
-      s_top_k_tokens[miss_offset] = my_token;
-      req_top_k_device_locs[my_token_idx] = req_device_buffer_locs[evict_slot];
-      req_device_buffer_tokens[evict_slot] = my_token;
-    }
-  }
-  __syncthreads();
-
-  total_misses = NUM_TOP_K - s_total_hits - s_newest_hit;
-  // Write back LRU order: evictables at front (LRU), hits at back (MRU).
-  {
-    const int total_evictable = HOT_BUFFER_SIZE - s_total_hits;
-    for (int i = tid; i < HOT_BUFFER_SIZE; i += BLOCK_SIZE) {
-      if (i < total_misses) {
-        // Misses: just loaded from host, place right before hits
-        req_lru_slots[total_evictable - total_misses + i] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
-      } else if (i < total_evictable) {
-        // Remaining evictables: truly stale, dest at LRU front
-        req_lru_slots[i - total_misses] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+    // Insert top-k tokens into shared-memory hash table.
+    for (int i = tid; i < NUM_TOP_K; i += BLOCK_SIZE) {
+      int32_t token_idx = step_top_k_tokens[i];
+      if (token_idx < 0 || token_idx >= seq_len) {
+        s_top_k_tokens[i] = TOKEN_HIT;
+        step_top_k_device_locs[i] = -1;
       } else {
-        // Hits: source at forward end, dest at MRU back
-        req_lru_slots[i] = s_lru_slots_out[i - total_evictable];
+        int32_t direct_loc = -1;
+        if (try_get_extra_page_device_loc<HOT_BUFFER_SIZE, IsDsv4Layout>(
+                token_idx,
+                seq_len,
+                step,
+                num_steps,
+                req_device_buffer_tokens,
+                req_device_buffer_locs,
+                page_size,
+                &direct_loc)) {
+          s_top_k_tokens[i] = TOKEN_HIT;
+          step_top_k_device_locs[i] = direct_loc;
+          continue;
+        }
+
+        int slot = hash_slot(token_idx, HASH_SIZE);
+        while (true) {
+          int32_t old = atomicCAS(&s_hash_keys[slot], HASH_EMPTY, token_idx);
+          if (old == HASH_EMPTY || old == token_idx) {
+            s_hash_vals[slot] = static_cast<int16_t>(i);
+            break;
+          }
+          slot = (slot + 1) % HASH_SIZE;
+        }
+        s_top_k_tokens[i] = token_idx;
       }
     }
-  }
+    __syncthreads();
 
-  // each warp copies one miss directly, can be separated into a new kernel if parallelism is a concern
-  for (int miss_idx = warp_id; miss_idx < total_misses; miss_idx += NUM_WARPS) {
-    const int32_t miss_token = s_top_k_tokens[miss_idx];
-    const int16_t evict_slot = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_idx];
+    // Scan device buffer slots in LRU order, marking hits and evictables.
+    constexpr int ITERATIONS_PER_WARP_BUFFER = (NUM_BUFFER_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
+    int total_hit_count = 0;
+    int total_evict_count = 0;
+    for (int iter = 0; iter < ITERATIONS_PER_WARP_BUFFER; iter++) {
+      int chunk_idx = warp_id + iter * NUM_WARPS;
+      bool has_valid_chunk = chunk_idx < NUM_BUFFER_CHUNKS;
 
-    const int64_t src_loc = req_host_cache_locs[miss_token];
-    const int64_t dst_loc = static_cast<int64_t>(req_device_buffer_locs[evict_slot]);
+      const int slot_idx = chunk_idx * WARP_SIZE + lane_id;
+      const bool has_valid_slot = has_valid_chunk && (slot_idx < HOT_BUFFER_SIZE);
+      const int16_t buf_slot = has_valid_slot ? req_lru_slots[slot_idx] : -1;
+      int32_t my_buffer_token = (buf_slot >= 0) ? req_device_buffer_tokens[buf_slot] : -1;
+      int my_found_top_k_idx = -1;
+      if (my_buffer_token >= 0) {
+        int h = hash_slot(my_buffer_token, HASH_SIZE);
+        while (true) {
+          int32_t k = s_hash_keys[h];
+          if (k == my_buffer_token) {
+            my_found_top_k_idx = static_cast<int32_t>(s_hash_vals[h]);
+            break;
+          }
+          if (k == HASH_EMPTY) break;
+          h = (h + 1) % HASH_SIZE;
+        }
+      }
+      bool is_hit = my_found_top_k_idx >= 0;
+      bool is_evictable = has_valid_slot && !is_hit;
 
-    if constexpr (IsDsv4Layout) {
-      // DSv4 path: page-padded device layout + page-padded host layout, K-only.
-      // The host cache is pinned DRAM but uses the same row layout as the GPU C4
-      // cache, so use the page-padded address calculation for both ends.
-      device::hisparse::transfer_item(
-          /*dst_cache=*/device_buffer_k,
-          /*src_cache=*/const_cast<void*>(host_cache_k),
-          /*dst_index=*/static_cast<int32_t>(dst_loc),
-          /*src_index=*/static_cast<int32_t>(src_loc));
-    } else {
-      // Generic path: device + host both linear, stride = item_size_bytes.
-      const auto src_k = static_cast<const char*>(host_cache_k) + src_loc * item_size_bytes;
-      auto dst_k = static_cast<char*>(device_buffer_k) + dst_loc * item_size_bytes;
-      transfer_item_warp(lane_id, src_k, dst_k, item_size_bytes);
+      if (is_hit) {
+        s_top_k_tokens[my_found_top_k_idx] = TOKEN_HIT;
+        step_top_k_device_locs[my_found_top_k_idx] = req_device_buffer_locs[buf_slot];
+      }
 
-      if constexpr (!IsMLA) {
-        const auto src_v = static_cast<const char*>(host_cache_v) + src_loc * item_size_bytes;
-        auto dst_v = static_cast<char*>(device_buffer_v) + dst_loc * item_size_bytes;
-        transfer_item_warp(lane_id, src_v, dst_v, item_size_bytes);
+      int local_hit_offset = 0;
+      int local_evict_offset = 0;
+      if (has_valid_chunk) {
+        const unsigned int hit_mask = __ballot_sync(0xFFFFFFFF, is_hit);
+        const unsigned int evict_mask = __ballot_sync(0xFFFFFFFF, is_evictable);
+        local_hit_offset = __popc(hit_mask & lanes_before);
+        local_evict_offset = __popc(evict_mask & lanes_before);
+        if (lane_id == 0) {
+          s_chunk_offset[chunk_idx + 1] = __popc(hit_mask);
+          s_evict_chunk_offset[chunk_idx + 1] = __popc(evict_mask);
+        }
+      }
+      __syncthreads();
+
+      if (warp_id == 0) {
+        total_hit_count =
+            warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_hit_count);
+        total_evict_count =
+            warp_inclusive_scan(s_evict_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_evict_count);
+        if (tid == 0) {
+          s_total_hits = total_hit_count;
+        }
+      }
+      __syncthreads();
+
+      if (is_hit) {
+        int hit_offset = s_chunk_offset[chunk_idx] + local_hit_offset;
+        s_lru_slots_out[hit_offset] = buf_slot;
+      }
+      if (is_evictable) {
+        int evict_offset = s_evict_chunk_offset[chunk_idx] + local_evict_offset;
+        s_lru_slots_out[HOT_BUFFER_SIZE - 1 - evict_offset] = buf_slot;
       }
     }
-  }
+    __syncthreads();
+
+    // Reset offsets for the miss counting phase.
+    for (int i = tid; i < NUM_TOKEN_CHUNKS + 1; i += BLOCK_SIZE) {
+      s_chunk_offset[i] = 0;
+    }
+    __syncthreads();
+
+    // Identify misses and assign evict slots.
+    int total_misses = 0;
+    constexpr int ITERATIONS_PER_WARP_TOKEN = (NUM_TOKEN_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
+    for (int iter = 0; iter < ITERATIONS_PER_WARP_TOKEN; iter++) {
+      int chunk_idx = warp_id + iter * NUM_WARPS;
+      bool has_valid_chunk = chunk_idx < NUM_TOKEN_CHUNKS;
+
+      const int chunk_token_start = chunk_idx * WARP_SIZE;
+      const int my_token_idx = chunk_token_start + lane_id;
+      const bool has_valid_token = has_valid_chunk && (my_token_idx < NUM_TOP_K);
+
+      int32_t my_token = 0;
+      bool is_miss = false;
+      int local_miss_offset = 0;
+
+      if (has_valid_token) {
+        is_miss = s_top_k_tokens[my_token_idx] != TOKEN_HIT;
+        if (is_miss) {
+          my_token = s_top_k_tokens[my_token_idx];
+          if (req_host_cache_locs[my_token] < 0) {
+            is_miss = false;
+            s_top_k_tokens[my_token_idx] = TOKEN_HIT;
+            step_top_k_device_locs[my_token_idx] = -1;
+          }
+        }
+      }
+
+      if (has_valid_chunk) {
+        const unsigned int miss_mask = __ballot_sync(0xFFFFFFFF, is_miss);
+        local_miss_offset = __popc(miss_mask & lanes_before);
+        const int warp_miss_count = __popc(miss_mask);
+        if (lane_id == 0) {
+          s_chunk_offset[chunk_idx + 1] = warp_miss_count;
+        }
+      }
+      __syncthreads();
+
+      if (warp_id == 0) {
+        total_misses = warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_TOKEN_CHUNKS + 1, total_misses);
+        if (tid == 0) {
+          s_total_misses = total_misses;
+        }
+      }
+      __syncthreads();
+
+      if (is_miss) {
+        int miss_offset = s_chunk_offset[chunk_idx] + local_miss_offset;
+        int16_t evict_slot = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_offset];
+        s_top_k_tokens[miss_offset] = my_token;
+        step_top_k_device_locs[my_token_idx] = req_device_buffer_locs[evict_slot];
+        req_device_buffer_tokens[evict_slot] = my_token;
+      }
+    }
+    __syncthreads();
+
+    total_misses = s_total_misses;
+
+    // Write back LRU order: evictables at front (LRU), hits at back (MRU).
+    {
+      const int total_evictable = HOT_BUFFER_SIZE - s_total_hits;
+      for (int i = tid; i < HOT_BUFFER_SIZE; i += BLOCK_SIZE) {
+        if (i < total_misses) {
+          req_lru_slots[total_evictable - total_misses + i] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+        } else if (i < total_evictable) {
+          req_lru_slots[i - total_misses] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+        } else {
+          req_lru_slots[i] = s_lru_slots_out[i - total_evictable];
+        }
+      }
+    }
+
+    // Copy missed pages from host to device buffer.
+    for (int miss_idx = warp_id; miss_idx < total_misses; miss_idx += NUM_WARPS) {
+      const int32_t miss_token = s_top_k_tokens[miss_idx];
+      const int16_t evict_slot = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_idx];
+
+      const int64_t src_loc = req_host_cache_locs[miss_token];
+      const int64_t dst_loc = static_cast<int64_t>(req_device_buffer_locs[evict_slot]);
+
+      if constexpr (IsDsv4Layout) {
+        // DSv4 path: page-padded device layout + page-padded host layout, K-only.
+        // The host cache is pinned DRAM but uses the same row layout as the GPU C4
+        // cache, so use the page-padded address calculation for both ends.
+        device::hisparse::transfer_item(
+            /*dst_cache=*/device_buffer_k,
+            /*src_cache=*/const_cast<void*>(host_cache_k),
+            /*dst_index=*/static_cast<int32_t>(dst_loc),
+            /*src_index=*/static_cast<int32_t>(src_loc));
+      } else {
+        const auto src_k = static_cast<const char*>(host_cache_k) + src_loc * item_size_bytes;
+        auto dst_k = static_cast<char*>(device_buffer_k) + dst_loc * item_size_bytes;
+        transfer_item_warp(lane_id, src_k, dst_k, item_size_bytes);
+
+        if constexpr (!IsMLA) {
+          const auto src_v = static_cast<const char*>(host_cache_v) + src_loc * item_size_bytes;
+          auto dst_v = static_cast<char*>(device_buffer_v) + dst_loc * item_size_bytes;
+          transfer_item_warp(lane_id, src_v, dst_v, item_size_bytes);
+        }
+      }
+    }
+
+    // Ensure global writes (device_buffer_tokens, lru_slots) are visible to next step.
+    if (num_steps > 1) {
+      __threadfence_block();
+      __syncthreads();
+    }
+  }  // end step loop
 }
 
 template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, bool IsMLA, bool IsDsv4Layout>
@@ -472,7 +563,8 @@ void load_cache_to_device_buffer(
     tvm::ffi::TensorView lru_slots,
     tvm::ffi::TensorView num_real_reqs,
     int64_t page_size,
-    int64_t item_size_bytes) {
+    int64_t item_size_bytes,
+    int64_t num_steps) {
   using namespace host;
 
   const int64_t bs = top_k_tokens.shape()[0];
@@ -483,8 +575,6 @@ void load_cache_to_device_buffer(
   const int64_t top_k_device_locs_stride = top_k_device_locs.strides()[0];
   const auto device = LaunchKernel::resolve_device(top_k_tokens.device());
 
-  // Generic lambda: int32/int64 kernel variants are compiled for both
-  // seq_lens and req_pool_indices; the correct combo is selected at runtime.
   auto launch = [&](auto kernel_fn, const auto* seq_lens_ptr, const auto* req_pool_indices_ptr) {
     constexpr size_t smem_bytes = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>::BYTES;
     if constexpr (smem_bytes > 48u * 1024u) {
@@ -511,7 +601,8 @@ void load_cache_to_device_buffer(
         top_k_tokens_stride,
         top_k_device_locs_stride,
         page_size,
-        item_size_bytes);
+        item_size_bytes,
+        num_steps);
   };
 
   const auto seq_dtype = seq_lens.dtype();

--- a/python/sglang/jit_kernel/hisparse.py
+++ b/python/sglang/jit_kernel/hisparse.py
@@ -10,6 +10,8 @@ from sglang.jit_kernel.utils import load_jit, make_cpp_args
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
+_HISPARSE_JIT_CACHE_VERSION = 6
+
 
 @functools.cache
 def _jit_sparse_module(
@@ -24,7 +26,13 @@ def _jit_sparse_module(
         block_size, num_top_k, hot_buffer_size, is_mla, is_dsv4_layout
     )
     cache_args = make_cpp_args(
-        item_size_bytes, block_size, num_top_k, hot_buffer_size, is_mla, is_dsv4_layout
+        _HISPARSE_JIT_CACHE_VERSION,
+        item_size_bytes,
+        block_size,
+        num_top_k,
+        hot_buffer_size,
+        is_mla,
+        is_dsv4_layout,
     )
     return load_jit(
         "sparse_cache",
@@ -91,6 +99,7 @@ def _load_cache_to_device_buffer_mla(
     page_size: int,
     block_size: int,
     num_real_reqs: torch.Tensor | None,
+    num_steps: int = 1,
 ) -> None:
     assert (
         hot_buffer_size >= num_top_k
@@ -128,6 +137,7 @@ def _load_cache_to_device_buffer_mla(
         num_real_reqs,
         page_size,
         item_size_bytes,
+        num_steps,
     )
 
 
@@ -148,6 +158,7 @@ def load_cache_to_device_buffer_mla(
     page_size: int = 1,
     block_size: int = 256,
     num_real_reqs: torch.Tensor | None = None,
+    num_steps: int = 1,
 ) -> None:
     """Generic MLA hisparse swap-in: device + host both linear (stride=item_size_bytes)."""
     _load_cache_to_device_buffer_mla(
@@ -168,6 +179,7 @@ def load_cache_to_device_buffer_mla(
         page_size=page_size,
         block_size=block_size,
         num_real_reqs=num_real_reqs,
+        num_steps=num_steps,
     )
 
 
@@ -188,6 +200,7 @@ def load_cache_to_device_buffer_dsv4_mla(
     page_size: int = 1,
     block_size: int = 256,
     num_real_reqs: torch.Tensor | None = None,
+    num_steps: int = 1,
 ) -> None:
     """DSv4 hisparse swap-in: page-padded device + page-padded host C4 layout."""
     _load_cache_to_device_buffer_mla(
@@ -208,4 +221,5 @@ def load_cache_to_device_buffer_dsv4_mla(
         page_size=page_size,
         block_size=block_size,
         num_real_reqs=num_real_reqs,
+        num_steps=num_steps,
     )

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -37,6 +37,7 @@ class KVArgs:
     kv_data_ptrs: List[int]
     kv_data_lens: List[int]
     kv_item_lens: List[int]
+    target_kv_data_ptr_count: int
     aux_data_ptrs: List[int]
     aux_data_lens: List[int]
     aux_item_lens: List[int]

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -153,6 +153,7 @@ class CommonKVManager(BaseKVManager):
         self._socket_cache: Dict[str, zmq.Socket] = {}
         self._monitor_cache: Dict[str, zmq.Socket] = {}
         self._socket_lock = threading.Lock()
+        self.status_lock = threading.RLock()
         self.failure_records: Dict[int, str] = {}
         self.failure_lock = threading.Lock()
 
@@ -209,24 +210,33 @@ class CommonKVManager(BaseKVManager):
             )
 
     def check_status(self, bootstrap_room: int) -> KVPoll:
-        return self.request_status[bootstrap_room]
+        with self.status_lock:
+            return self.request_status[bootstrap_room]
 
     def update_status(self, bootstrap_room: int, status: KVPoll):
-        if bootstrap_room not in self.request_status:
-            # Do not resurrect a cleared entry with Failed: once clear() has
-            # popped the room from request_status, any late update_status(Failed)
-            # (e.g. from abort()) must be a no-op. Otherwise a Failed entry could
-            # pollute a future request that reuses the same bootstrap_room.
-            if status == KVPoll.Failed:
-                return
-            self.request_status[bootstrap_room] = status
-        else:
-            if status == KVPoll.Failed:
-                self.request_status[bootstrap_room] = KVPoll.Failed
+        with self.status_lock:
+            if bootstrap_room not in self.request_status:
+                # Do not resurrect a cleared entry with Failed: once clear() has
+                # popped the room from request_status, any late update_status(Failed)
+                # (e.g. from abort()) must be a no-op. Otherwise a Failed entry could
+                # pollute a future request that reuses the same bootstrap_room.
+                if status == KVPoll.Failed:
+                    return
+                self.request_status[bootstrap_room] = status
             else:
-                self.request_status[bootstrap_room] = max(
-                    self.request_status[bootstrap_room], status
-                )
+                if status == KVPoll.Failed:
+                    self.request_status[bootstrap_room] = KVPoll.Failed
+                else:
+                    self.request_status[bootstrap_room] = max(
+                        self.request_status[bootstrap_room], status
+                    )
+
+    def update_status_if_present(self, bootstrap_room: int, status: KVPoll) -> bool:
+        with self.status_lock:
+            if bootstrap_room not in self.request_status:
+                return False
+            self.update_status(bootstrap_room, status)
+            return True
 
     def record_failure(self, bootstrap_room: int, failure_reason: str):
         with self.failure_lock:
@@ -910,11 +920,12 @@ class CommonKVSender(BaseKVSender):
         raise Exception("Fake KVReceiver Exception")
 
     def clear(self) -> None:
-        self.kv_mgr.request_status.pop(self.bootstrap_room, None)
-        if hasattr(self.kv_mgr, "req_to_decode_prefix_len"):
-            self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, None)
-        if hasattr(self.kv_mgr, "transfer_infos"):
-            self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
+        with self.kv_mgr.status_lock:
+            self.kv_mgr.request_status.pop(self.bootstrap_room, None)
+            if hasattr(self.kv_mgr, "req_to_decode_prefix_len"):
+                self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, None)
+            if hasattr(self.kv_mgr, "transfer_infos"):
+                self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
 
     def abort(self):
         self.kv_mgr.record_failure(
@@ -1155,9 +1166,12 @@ class CommonKVReceiver(BaseKVReceiver):
         raise Exception("Fake KVReceiver Exception")
 
     def clear(self) -> None:
-        self.kv_mgr.request_status.pop(self.bootstrap_room, None)
-        self.kv_mgr.required_prefill_response_num_table.pop(self.bootstrap_room, None)
-        self.kv_mgr.prefill_response_tracker.pop(self.bootstrap_room, None)
+        with self.kv_mgr.status_lock:
+            self.kv_mgr.request_status.pop(self.bootstrap_room, None)
+            self.kv_mgr.required_prefill_response_num_table.pop(
+                self.bootstrap_room, None
+            )
+            self.kv_mgr.prefill_response_tracker.pop(self.bootstrap_room, None)
 
     def abort(self):
         self.kv_mgr.record_failure(

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -181,6 +181,10 @@ class CommonKVManager(BaseKVManager):
             # fail to receive the KV indices from the decode instance of this request.
             # These timeout requests should be aborted to release the tree cache.
             self.bootstrap_timeout = envs.SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT.get()
+            # After KV transfer starts, prefill also needs a bounded wait for
+            # the final transfer status. Otherwise a dead decode session can
+            # leave requests in the prefill inflight queue forever.
+            self.waiting_timeout = envs.SGLANG_DISAGGREGATION_WAITING_TIMEOUT.get()
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
             self.enable_staging: bool = False
             self.connection_pool: Dict[str, Dict[str, Union[str, int]]] = {}

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -599,6 +599,11 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             full_allocatable_tokens = self._allocatable_token_budgets(
                 count_retracted=False
             )
+        hisparse_host_allocatable_tokens = (
+            self._hisparse_host_allocatable_token_budget(count_retracted=False)
+            if self.scheduler.enable_hisparse
+            else int(1e18)
+        )
 
         for i, req in enumerate(self.retracted_queue):
             if rids_to_check is not None and req.rid not in rids_to_check:
@@ -612,6 +617,10 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 break
             if uses_swa_tail_prealloc and swa_required > swa_allocatable_tokens:
                 break
+            if self.scheduler.enable_hisparse:
+                host_required = self._hisparse_host_required_tokens(req)
+                if host_required > hisparse_host_allocatable_tokens:
+                    break
 
             if self._pre_alloc(req) is None:
                 break
@@ -621,6 +630,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             full_allocatable_tokens -= full_required
             if uses_swa_tail_prealloc:
                 swa_allocatable_tokens -= swa_required
+            if self.scheduler.enable_hisparse:
+                hisparse_host_allocatable_tokens -= host_required
 
             if self.scheduler.enable_hisparse:
                 self.scheduler.hisparse_coordinator.admit_request_direct(req)
@@ -820,18 +831,22 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             self.queue.sort(key=lambda r: r.req.priority * priority_sign)
 
         # First, remove all failed requests from the queue
+        aborted_rids = set()
         for i, decode_req in enumerate(self.queue):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
             if isinstance(decode_req.req.finished_reason, FINISH_ABORT):
+                decode_req.kv_receiver.abort()
+                if hasattr(decode_req.kv_receiver, "clear"):
+                    decode_req.kv_receiver.clear()
                 self.scheduler.output_streamer.stream_output(
                     [decode_req.req],
                     decode_req.req.return_logprob,
                 )
-                decode_req.kv_receiver.clear()
                 decode_req.kv_receiver = None
                 failed_reqs.append(decode_req)
                 indices_to_remove.add(i)
+                aborted_rids.add(decode_req.req.rid)
 
         # HiSparse physical constraint: max requests by device buffer capacity.
         # Each admitted req needs padded_buffer_size from hisparse device pool.
@@ -847,6 +862,11 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 hisparse_avail // self.scheduler.hisparse_coordinator.padded_buffer_size
                 - len(self.transfer_queue.queue),
             )
+            hisparse_host_allocatable_tokens = (
+                self._hisparse_host_allocatable_token_budget(count_retracted=True)
+            )
+        else:
+            hisparse_host_allocatable_tokens = int(1e18)
 
         # Then, preallocate the remaining requests if possible
         for i, decode_req in enumerate(self.queue):
@@ -946,6 +966,22 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                         self.tree_cache.dec_lock_ref(decode_req.req.last_node)
                     break
 
+            if self.scheduler.enable_hisparse:
+                hisparse_host_required = self._hisparse_host_required_tokens(
+                    decode_req.req
+                )
+                if hisparse_host_required > hisparse_host_allocatable_tokens:
+                    logger.debug(
+                        "HiSparse host prealloc budget blocked req %s: need=%d, allocatable=%d, available=%d",
+                        decode_req.req.rid,
+                        hisparse_host_required,
+                        hisparse_host_allocatable_tokens,
+                        self.scheduler.hisparse_coordinator.mem_pool_host.available_size(),
+                    )
+                    if prefix_len > 0:
+                        self.tree_cache.dec_lock_ref(decode_req.req.last_node)
+                    break
+
             dst_kv_indices = self._pre_alloc(
                 decode_req.req,
                 prefix_indices,
@@ -974,6 +1010,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 # SWA budget uses simple decrement (no radix cache eviction in
                 # the SWA pool, so page-rounding drift is negligible).
                 swa_allocatable_tokens -= swa_required
+            if self.scheduler.enable_hisparse:
+                hisparse_host_allocatable_tokens -= hisparse_host_required
             decode_req.req.cache_protected_len = total_prefix_len
 
             page_size = self.token_to_kv_pool_allocator.page_size
@@ -1091,6 +1129,12 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         self.queue = [
             entry for i, entry in enumerate(self.queue) if i not in indices_to_remove
         ]
+        if aborted_rids:
+            self.pending_reqs = [
+                decode_req
+                for decode_req in self.pending_reqs
+                if decode_req.req.rid not in aborted_rids
+            ]
 
         return preallocated_reqs, failed_reqs
 
@@ -1130,6 +1174,89 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         if n_active is None:
             n_active = self._active_req_count(extra_reserved_reqs)
         return self.num_reserved_decode_tokens * n_active
+
+    def _req_prealloc_full_len(self, req: Req) -> int:
+        return len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
+
+    def _req_committed_full_len(self, req: Req) -> int:
+        full_len = getattr(req, "kv_committed_len", None)
+        if full_len is None or full_len <= 0:
+            return self._req_prealloc_full_len(req)
+        return int(full_len)
+
+    def _req_remaining_decode_tokens(self, req: Req) -> int:
+        committed_output_len = max(
+            0, self._req_committed_full_len(req) - len(req.origin_input_ids)
+        )
+        max_new_tokens = min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKEN)
+        return max(0, max_new_tokens - committed_output_len)
+
+    def _hisparse_host_decode_reserve_len(
+        self, req: Req, num_decode_tokens: Optional[int] = None
+    ) -> int:
+        coordinator = self.scheduler.hisparse_coordinator
+        if num_decode_tokens is None:
+            num_decode_tokens = self.num_reserved_decode_tokens
+        return coordinator.host_decode_reserve_len(
+            self._req_committed_full_len(req), num_decode_tokens
+        )
+
+    def _hisparse_host_remaining_decode_reserve_len(self, req: Req) -> int:
+        return self._hisparse_host_decode_reserve_len(
+            req, self._req_remaining_decode_tokens(req)
+        )
+
+    def _hisparse_retracted_host_len(self, req: Req) -> int:
+        host_len = getattr(req, "hisparse_retracted_host_len", None)
+        if host_len is not None:
+            return int(host_len)
+        host_indices = getattr(req, "hisparse_retracted_host_indices", None)
+        return int(host_indices.numel()) if host_indices is not None else 0
+
+    def _hisparse_host_required_tokens(self, req: Req) -> int:
+        coordinator = self.scheduler.hisparse_coordinator
+        fill_len = self._req_prealloc_full_len(req)
+        host_len = coordinator.compressed_host_len(fill_len)
+        preserved_host_len = self._hisparse_retracted_host_len(req)
+        prompt_need = max(0, host_len - preserved_host_len)
+        return prompt_need + self._hisparse_host_remaining_decode_reserve_len(req)
+
+    def _hisparse_host_reserved_tokens(self, extra_reserved_reqs: int = 0) -> int:
+        coordinator = self.scheduler.hisparse_coordinator
+        reserved = 0
+
+        for req in self.scheduler.running_batch.reqs:
+            reserved += self._hisparse_host_remaining_decode_reserve_len(req)
+        for decode_req in self.transfer_queue.queue:
+            reserved += self._hisparse_host_remaining_decode_reserve_len(decode_req.req)
+        for req in self.scheduler.waiting_queue:
+            reserved += self._hisparse_host_remaining_decode_reserve_len(req)
+
+        last_batch = self.scheduler.last_batch
+        if last_batch and last_batch.forward_mode.is_prebuilt():
+            for req in last_batch.reqs:
+                reserved += self._hisparse_host_remaining_decode_reserve_len(req)
+
+        extra_reserve = coordinator.host_decode_reserve_len(
+            0, self.num_reserved_decode_tokens
+        )
+        return reserved + extra_reserve * extra_reserved_reqs
+
+    def _hisparse_host_allocatable_token_budget(
+        self, count_retracted: bool = True, extra_reserved_reqs: int = 0
+    ) -> int:
+        if not self.scheduler.enable_hisparse:
+            return int(1e18)
+
+        coordinator = self.scheduler.hisparse_coordinator
+        allocatable_tokens = (
+            coordinator.mem_pool_host.available_size()
+            - self._hisparse_host_reserved_tokens(extra_reserved_reqs)
+        )
+        if count_retracted:
+            for req in self.retracted_queue:
+                allocatable_tokens -= self._hisparse_host_required_tokens(req)
+        return allocatable_tokens
 
     def _swa_aware_allocatable_token_budgets(
         self,
@@ -1363,7 +1490,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
                 extend_num_tokens=fill_len,
             )
-            host_len = coordinator.host_token_len(fill_len)
+            host_len = coordinator.compressed_host_len(fill_len)
             host_indices = coordinator.pop_retracted_host_indices(req, host_len)
             if host_indices is None:
                 # Allocate host indices for the RDMA transfer target.
@@ -1377,8 +1504,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     )
                 except RuntimeError:
                     logger.warning(
-                        "HiSparse host prealloc skipped for req %s: need=%d, "
-                        "available=%d",
+                        "HiSparse host prealloc skipped for req %s: need=%d, available=%d",
                         req.rid,
                         host_len,
                         coordinator.mem_pool_host.available_size(),

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -408,7 +408,13 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             kv_data_ptrs += device_kv_data_ptrs[c4_layer_num:]
             kv_data_lens += device_kv_data_lens[c4_layer_num:]
             kv_item_lens += device_kv_item_lens[c4_layer_num:]
-        if self.draft_token_to_kv_pool is not None:
+        kv_args.target_kv_data_ptr_count = len(kv_data_ptrs)
+        # HiSparse direct-to-host uses host-pool indices for target KV transfer.
+        # Draft KV remains device-indexed and cannot share that destination list.
+        if (
+            self.draft_token_to_kv_pool is not None
+            and not self.scheduler.enable_hisparse
+        ):
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -167,13 +167,13 @@ class DecodeReqToTokenPool:
         offset = 0
         for r in reqs:
             if r.req_pool_idx is None:
-                r.req_pool_idx = select_index[offset]
+                r.req_pool_idx = int(select_index[offset])
                 offset += 1
-        return [r.req_pool_idx for r in reqs]
+        return [int(r.req_pool_idx) for r in reqs]
 
     def free(self, req: Req):
         assert req.req_pool_idx is not None, "request must have req_pool_idx"
-        self.free_slots.append(req.req_pool_idx)
+        self.free_slots.append(int(req.req_pool_idx))
         req.req_pool_idx = None
 
     def clear(self):
@@ -613,16 +613,22 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             if uses_swa_tail_prealloc and swa_required > swa_allocatable_tokens:
                 break
 
+            if self._pre_alloc(req) is None:
+                break
             resumed_reqs.append(req)
             indices_to_remove.add(i)
             req.is_retracted = False
-            self._pre_alloc(req)
             full_allocatable_tokens -= full_required
             if uses_swa_tail_prealloc:
                 swa_allocatable_tokens -= swa_required
 
-            # load from cpu, release the cpu copy
-            req.load_kv_cache(self.req_to_token_pool, self.token_to_kv_pool_allocator)
+            if self.scheduler.enable_hisparse:
+                self.scheduler.hisparse_coordinator.admit_request_direct(req)
+            else:
+                # load from cpu, release the cpu copy
+                req.load_kv_cache(
+                    self.req_to_token_pool, self.token_to_kv_pool_allocator
+                )
 
         self.retracted_queue = [
             entry
@@ -946,6 +952,10 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 prefix_len,
                 total_prefix_len,
             )
+            if dst_kv_indices is None:
+                if prefix_len > 0:
+                    self.tree_cache.dec_lock_ref(decode_req.req.last_node)
+                break
             decode_req.prefix_match = prefix_match
             if self.scheduler.enable_decode_hicache:
                 self._start_hicache_prefetch(decode_req.req, prefix_match)
@@ -1277,7 +1287,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         prefix_indices: Optional[torch.Tensor] = None,
         prefix_len: Optional[int] = None,
         total_prefix_len: Optional[int] = None,
-    ) -> torch.Tensor:
+    ) -> Optional[torch.Tensor]:
         """Pre-allocate the memory for req_to_token and token_kv_pool.
 
         ``prefix_len`` is the L1 device-resident prefix length (already
@@ -1353,15 +1363,35 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
                 extend_num_tokens=fill_len,
             )
-
-            # Allocate host indices for the RDMA transfer target.
-            host_indices = coordinator.mem_pool_host.alloc_paged_token_slots(
-                coordinator.req_to_host_pool,
-                coordinator.req_to_host_pool_allocated_len,
-                req.req_pool_idx,
-                0,
-                coordinator.host_token_len(fill_len),
-            )
+            host_len = coordinator.host_token_len(fill_len)
+            host_indices = coordinator.pop_retracted_host_indices(req, host_len)
+            if host_indices is None:
+                # Allocate host indices for the RDMA transfer target.
+                try:
+                    host_indices = coordinator.mem_pool_host.alloc_paged_token_slots(
+                        coordinator.req_to_host_pool,
+                        coordinator.req_to_host_pool_allocated_len,
+                        req.req_pool_idx,
+                        0,
+                        host_len,
+                    )
+                except RuntimeError:
+                    logger.warning(
+                        "HiSparse host prealloc skipped for req %s: need=%d, "
+                        "available=%d",
+                        req.rid,
+                        host_len,
+                        coordinator.mem_pool_host.available_size(),
+                    )
+                    self.token_to_kv_pool_allocator.logical_attn_allocator.free(kv_loc)
+                    self.req_to_token_pool.free(req)
+                    req.kv_allocated_len = 0
+                    req.kv_committed_len = 0
+                    return None
+            else:
+                host_indices = host_indices.to(device=coordinator.device)
+                coordinator.req_to_host_pool[req.req_pool_idx, :host_len] = host_indices
+                coordinator.req_to_host_pool_allocated_len[req.req_pool_idx] = host_len
         elif self.token_to_kv_pool_allocator.page_size == 1:
             kv_loc = self.token_to_kv_pool_allocator.alloc(delta_len)
         else:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -133,8 +133,8 @@ class KVArgsRegisterInfo:
             endpoint=msg[1].decode("ascii"),
             dst_port=int(msg[2].decode("ascii")),
             mooncake_session_id=msg[3].decode("ascii"),
-            dst_kv_ptrs=list(struct.unpack(f"{len(msg[4])//8}Q", msg[4])),
-            dst_aux_ptrs=list(struct.unpack(f"{len(msg[5])//8}Q", msg[5])),
+            dst_kv_ptrs=list(struct.unpack(f"{len(msg[4]) // 8}Q", msg[4])),
+            dst_aux_ptrs=list(struct.unpack(f"{len(msg[5]) // 8}Q", msg[5])),
             dst_state_data_ptrs=unpack_int_lists(msg[6], "Q"),
             dst_tp_rank=int(msg[7].decode("ascii")),
             dst_attn_tp_size=int(msg[8].decode("ascii")),
@@ -152,6 +152,7 @@ class KVArgsRegisterInfo:
 
 class MooncakeKVManager(CommonKVManager):
     AUX_DATA_HEADER = b"AUX_DATA"
+    DECODE_STATUS_HEADER = b"STATUS"
 
     def __init__(
         self,
@@ -434,8 +435,7 @@ class MooncakeKVManager(CommonKVManager):
         )
         if ret == -1:
             logger.warning(
-                f"[Staging][tp{_tp}] Falling back to per-token slice path "
-                f"(room={kv_chunk.room})"
+                f"[Staging][tp{_tp}] Falling back to per-token slice path (room={kv_chunk.room})"
             )
             ret = self.send_kvcache_slice(
                 req.mooncake_session_id,
@@ -1244,6 +1244,8 @@ class MooncakeKVManager(CommonKVManager):
                     logger.debug(
                         f"Skipping chunk for room {kv_chunk.room} because it has already failed or been aborted"
                     )
+                    self.transfer_infos.pop(kv_chunk.room, None)
+                    self.req_to_decode_prefix_len.pop(kv_chunk.room, None)
                     if self.enable_trace:
                         kv_chunk.trace_ctx.trace_slice_end(
                             MooncakeRequestStage.MOONCAKE_WORKER_SEND.stage_name,
@@ -1475,6 +1477,9 @@ class MooncakeKVManager(CommonKVManager):
             while True:
                 waiting_req_bytes = self.server_socket.recv_multipart()
                 room = waiting_req_bytes[0].decode("ascii")
+                if room == MooncakeKVManager.DECODE_STATUS_HEADER.decode("ascii"):
+                    self._handle_prefill_decode_status(waiting_req_bytes)
+                    continue
                 # Staging: decode reports consumption watermark back to prefill
                 if room == "WATERMARK":
                     from sglang.srt.disaggregation.common.staging_handler import (
@@ -1565,6 +1570,27 @@ class MooncakeKVManager(CommonKVManager):
                         self.update_status(room, KVPoll.WaitingForInput)
 
         threading.Thread(target=bootstrap_thread).start()
+
+    def _handle_prefill_decode_status(self, msg):
+        room = int(msg[1].decode("ascii"))
+        status = int(msg[2].decode("ascii"))
+        reason = (
+            msg[3].decode("utf-8", errors="replace")
+            if len(msg) > 3
+            else "Decode instance failed before sending KV metadata"
+        )
+
+        if status != KVPoll.Failed:
+            return
+
+        with self.status_lock:
+            if room not in self.request_status:
+                return
+
+        self.record_failure(room, reason)
+        self.update_status(room, KVPoll.Failed)
+        self.transfer_infos.pop(room, None)
+        self.req_to_decode_prefix_len.pop(room, None)
 
     def start_decode_thread(self):
         def decode_thread():
@@ -1757,7 +1783,6 @@ class MooncakeKVManager(CommonKVManager):
 
 
 class MooncakeKVSender(CommonKVSender):
-
     def __init__(
         self,
         mgr: MooncakeKVManager,
@@ -1769,6 +1794,7 @@ class MooncakeKVSender(CommonKVSender):
         super().__init__(mgr, bootstrap_addr, bootstrap_room, dest_tp_ranks, pp_rank)
         self.conclude_state = None
         self.init_time = None
+        self.transfer_init_time = None
         self._init_trace_ctx()
 
     @mooncake_trace_func(MooncakeRequestStage.MOONCAKE_SEND)
@@ -1819,7 +1845,28 @@ class MooncakeKVSender(CommonKVSender):
                     self.init_time = time.time()
                 timeout_result = self._check_bootstrap_timeout()
                 if timeout_result is not None:
+                    self.conclude_state = timeout_result
+                    self.trace_ctx.trace_req_finish()
                     return timeout_result
+            elif status == KVPoll.Transferring:
+                if self.transfer_init_time is None:
+                    self.transfer_init_time = time.time()
+                now = time.time()
+                elapsed = now - self.transfer_init_time
+                if elapsed >= self.kv_mgr.waiting_timeout:
+                    logger.warning_once(
+                        "Some requests timed out after prefill KV transfer started, "
+                        "which means prefill instances did not observe a terminal transfer status. "
+                        "If a greater mean TTFT is acceptable, you can 'export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=600' (10 minutes) to relax the timeout condition. "
+                    )
+                    self.kv_mgr.record_failure(
+                        self.bootstrap_room,
+                        f"Request {self.bootstrap_room} timed out after {elapsed:.1f}s in KVPoll.Transferring on prefill sender",
+                    )
+                    self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
+                    self.conclude_state = KVPoll.Failed
+                    self.trace_ctx.trace_req_finish()
+                    return KVPoll.Failed
 
             return status
         else:
@@ -1974,6 +2021,47 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         str(decode_prefix_len or 0).encode("ascii"),
                     ]
                 )
+
+    def _notify_prefill_status(self, status: int, reason: str = "") -> bool:
+        bootstrap_infos = getattr(self, "bootstrap_infos", None)
+        if not bootstrap_infos:
+            return False
+
+        sent = False
+        for bootstrap_info in bootstrap_infos:
+            try:
+                sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
+                with lock:
+                    sock.send_multipart(
+                        [
+                            MooncakeKVManager.DECODE_STATUS_HEADER,
+                            str(self.bootstrap_room).encode("ascii"),
+                            str(status).encode("ascii"),
+                            reason.encode("utf-8"),
+                        ]
+                    )
+                sent = True
+            except Exception as e:
+                logger.warning(
+                    "Failed to notify prefill status for bootstrap_room=%s: %s",
+                    self.bootstrap_room,
+                    e,
+                )
+        return sent
+
+    def abort(self, reason: str = "Aborted by AbortReq."):
+        try:
+            status = self.kv_mgr.check_status(self.bootstrap_room)
+        except KeyError:
+            status = None
+
+        if status is not None:
+            self.kv_mgr.record_failure(self.bootstrap_room, reason)
+            if status == KVPoll.Bootstrapping:
+                self._notify_prefill_status(KVPoll.Failed, reason)
+            self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
+
+        self.conclude_state = KVPoll.Failed
 
     def poll(self) -> KVPoll:
         if self.conclude_state is None:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -166,10 +166,10 @@ class MooncakeKVManager(CommonKVManager):
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
         self.enable_trace = server_args.enable_trace
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
-            self.start_prefill_thread()
             self.session_failures = defaultdict(int)
             self.failed_sessions = set()
             self.session_lock = threading.Lock()
+            self.start_prefill_thread()
             # Determine the number of threads to use for kv sender
             cpu_count = os.cpu_count()
             transfer_thread_pool_size = (
@@ -239,23 +239,31 @@ class MooncakeKVManager(CommonKVManager):
         self.engine = get_mooncake_transfer_engine()
 
     def register_buffer_to_engine(self):
+        def batch_register_or_raise(ptrs: list[int], lens: list[int], buffer_name: str):
+            ret = self.engine.batch_register(ptrs, lens)
+            if ret != 0:
+                raise RuntimeError(
+                    f"Mooncake failed to register {buffer_name} buffers "
+                    f"(count={len(ptrs)}, first_length={lens[0] if lens else 0})."
+                )
+
         # Batch register KV data buffers
         if self.kv_args.kv_data_ptrs and self.kv_args.kv_data_lens:
-            self.engine.batch_register(
-                self.kv_args.kv_data_ptrs, self.kv_args.kv_data_lens
+            batch_register_or_raise(
+                self.kv_args.kv_data_ptrs, self.kv_args.kv_data_lens, "KV data"
             )
 
         # Batch register auxiliary data buffers
         if self.kv_args.aux_data_ptrs and self.kv_args.aux_data_lens:
-            self.engine.batch_register(
-                self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens
+            batch_register_or_raise(
+                self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens, "auxiliary"
             )
 
-        for ptrs, lens in zip(
-            self.kv_args.state_data_ptrs, self.kv_args.state_data_lens
+        for index, (ptrs, lens) in enumerate(
+            zip(self.kv_args.state_data_ptrs, self.kv_args.state_data_lens)
         ):
             if ptrs and lens:
-                self.engine.batch_register(ptrs, lens)
+                batch_register_or_raise(ptrs, lens, f"state[{index}]")
 
     def deregister_buffer_to_engine(self):
         if self.kv_args.kv_data_ptrs:
@@ -700,6 +708,55 @@ class MooncakeKVManager(CommonKVManager):
             item_lens=self.kv_args.kv_item_lens,
             prefill_data_indices=prefill_kv_indices,
             dst_data_indices=dst_kv_indices,
+            executor=executor,
+        )
+
+    def send_kvcache_hisparse(
+        self,
+        mooncake_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        page_index_slice: slice,
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ):
+        """HiSparse transfer: prefill page_size > decode host page_size=1.
+
+        Receives page-level prefill_kv_indices and the full token-level
+        dst_kv_indices.  Expands both to token granularity before transfer.
+        """
+        page_size = self.kv_args.page_size
+        target_kv_ptr_count = getattr(
+            self.kv_args, "target_kv_data_ptr_count", len(self.kv_args.kv_data_ptrs)
+        )
+        src_data_ptrs = self.kv_args.kv_data_ptrs[:target_kv_ptr_count]
+        per_token_item_lens = [
+            il // page_size for il in self.kv_args.kv_item_lens[:target_kv_ptr_count]
+        ]
+
+        # Expand page-level src indices to token-level
+        base = np.repeat(prefill_kv_indices * page_size, page_size)
+        offsets = np.tile(np.arange(page_size, dtype=np.int32), len(prefill_kv_indices))
+        expanded_src = base + offsets
+
+        # Expand page-level index_slice to token-level for dst
+        token_start = page_index_slice.start * page_size
+        token_end = min(page_index_slice.stop * page_size, len(dst_kv_indices))
+        expanded_dst = dst_kv_indices[token_start:token_end]
+
+        # Clip src to match dst length (last page may be partial)
+        expanded_src = expanded_src[: len(expanded_dst)]
+
+        logger.debug(
+            f"Send KVCache for hisparse: {expanded_src.shape} -> {expanded_dst.shape}"
+        )
+        return self._send_kvcache_generic(
+            mooncake_session_id=mooncake_session_id,
+            src_data_ptrs=src_data_ptrs,
+            dst_data_ptrs=dst_kv_ptrs,
+            item_lens=per_token_item_lens,
+            prefill_data_indices=expanded_src,
+            dst_data_indices=expanded_dst,
             executor=executor,
         )
 
@@ -1208,12 +1265,33 @@ class MooncakeKVManager(CommonKVManager):
                 )
                 polls = []
                 dst_ranks_infos = []
+                status = self.request_status.get(kv_chunk.room)
+                if status == KVPoll.Failed:
+                    self.transfer_infos.pop(kv_chunk.room, None)
+                    self.req_to_decode_prefix_len.pop(kv_chunk.room, None)
+                    continue
+
                 # Unique id per prefill sender so decode's response set size matches expected_response_num.
                 prefill_unique_rank = (
                     self.attn_tp_rank * (self.pp_size * self.attn_cp_size)
                     + self.pp_rank * self.attn_cp_size
                     + self.attn_cp_rank
                 )
+                if status not in (
+                    None,
+                    KVPoll.Failed,
+                    KVPoll.Transferring,
+                    KVPoll.Success,
+                ):
+                    self.update_status(kv_chunk.room, KVPoll.Transferring)
+                    for req in reqs_to_be_processed:
+                        self.sync_status_to_decode_endpoint(
+                            req.endpoint,
+                            req.dst_port,
+                            req.room,
+                            KVPoll.Transferring,
+                            prefill_unique_rank,
+                        )
                 # When staging transfer is not yet ready (watermark/allocation pending),
                 # the chunk is re-enqueued and we break out of the req loop to retry later.
                 staging_deferred = False
@@ -1534,31 +1612,51 @@ class MooncakeKVManager(CommonKVManager):
                 bootstrap_room = int(bootstrap_room.decode("ascii"))
                 prefill_rank = int(prefill_rank.decode("ascii"))
 
-                if status == KVPoll.Success:
-                    if bootstrap_room in self.request_status:
-                        self.prefill_response_tracker[bootstrap_room].add(prefill_rank)
-                        expected_response_num = (
-                            self.required_prefill_response_num_table[bootstrap_room]
-                        )
-                        arrived_response_num = len(
-                            self.prefill_response_tracker[bootstrap_room]
-                        )
-                        if arrived_response_num == expected_response_num:
-                            if self.enable_staging:
-                                handler = self._staging_handler
-                                if handler.is_staging_room(bootstrap_room):
-                                    handler.submit_last_scatter_async(bootstrap_room)
-                                self._chunk_writer_counts.pop(bootstrap_room, None)
-                            self.update_status(bootstrap_room, KVPoll.Success)
-                elif status == KVPoll.Failed:
-                    self.record_failure(
-                        bootstrap_room,
-                        "Failed to get kvcache from prefill instance, it might be dead",
-                    )
-                    self.update_status(bootstrap_room, status)
+                self._handle_decode_status(bootstrap_room, status, prefill_rank)
 
         threading.Thread(target=decode_thread).start()
         self._start_heartbeat_checker_thread()
+
+    def _handle_decode_status(
+        self, bootstrap_room: int, status: int, prefill_rank: int
+    ):
+        if status == KVPoll.Success:
+            with self.status_lock:
+                if bootstrap_room not in self.request_status:
+                    self.prefill_response_tracker.pop(bootstrap_room, None)
+                    return
+
+                expected_response_num = self.required_prefill_response_num_table.get(
+                    bootstrap_room
+                )
+                if expected_response_num is None:
+                    self.prefill_response_tracker.pop(bootstrap_room, None)
+                    return
+
+                self.prefill_response_tracker[bootstrap_room].add(prefill_rank)
+                arrived_response_num = len(
+                    self.prefill_response_tracker[bootstrap_room]
+                )
+                should_complete = arrived_response_num == expected_response_num
+
+            if should_complete:
+                if self.enable_staging:
+                    handler = self._staging_handler
+                    if handler.is_staging_room(bootstrap_room):
+                        handler.submit_last_scatter_async(bootstrap_room)
+                    self._chunk_writer_counts.pop(bootstrap_room, None)
+                self.update_status_if_present(bootstrap_room, KVPoll.Success)
+        elif status == KVPoll.Failed:
+            with self.status_lock:
+                if bootstrap_room not in self.request_status:
+                    return
+                self.record_failure(
+                    bootstrap_room,
+                    "Failed to get kvcache from prefill instance, it might be dead",
+                )
+                self.update_status(bootstrap_room, status)
+        elif status == KVPoll.Transferring:
+            self.update_status_if_present(bootstrap_room, status)
 
     def add_transfer_request(
         self,
@@ -1670,7 +1768,7 @@ class MooncakeKVSender(CommonKVSender):
     ):
         super().__init__(mgr, bootstrap_addr, bootstrap_room, dest_tp_ranks, pp_rank)
         self.conclude_state = None
-        self.init_time = time.time()
+        self.init_time = None
         self._init_trace_ctx()
 
     @mooncake_trace_func(MooncakeRequestStage.MOONCAKE_SEND)
@@ -1712,6 +1810,13 @@ class MooncakeKVSender(CommonKVSender):
                 self.conclude_state = status
                 self.trace_ctx.trace_req_finish()
             elif status == KVPoll.Bootstrapping:
+                # Queueing before decode admission is valid backpressure. Start
+                # the bootstrap timeout only after decode begins sending metadata.
+                if (
+                    self.init_time is None
+                    and self.bootstrap_room in self.kv_mgr.transfer_infos
+                ):
+                    self.init_time = time.time()
                 timeout_result = self._check_bootstrap_timeout()
                 if timeout_result is not None:
                     return timeout_result
@@ -1869,21 +1974,24 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         str(decode_prefix_len or 0).encode("ascii"),
                     ]
                 )
-        self.init_time = time.time()
 
     def poll(self) -> KVPoll:
-        if self.conclude_state is not None:
+        if self.conclude_state is None:
+            status = self.kv_mgr.check_status(self.bootstrap_room)
+            if status in (KVPoll.Success, KVPoll.Failed):
+                self.conclude_state = status
+            elif status == KVPoll.Transferring:
+                if self.init_time is None:
+                    self.init_time = time.time()
+                timeout_result = self._check_waiting_timeout()
+                if timeout_result is not None:
+                    self.conclude_state = timeout_result
+                    return timeout_result
+
+            return status
+
+        else:
             return self.conclude_state
-
-        status = self.kv_mgr.check_status(self.bootstrap_room)
-        if status in (KVPoll.Success, KVPoll.Failed):
-            self.conclude_state = status
-        elif status == KVPoll.WaitingForInput:
-            timeout_result = self._check_waiting_timeout()
-            if timeout_result is not None:
-                return timeout_result
-
-        return status
 
     def failure_exception(self):
         if self.conclude_state is None:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -24,7 +24,7 @@ import logging
 from array import array
 from collections import deque
 from http import HTTPStatus
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Deque, List, Optional
 
 import numpy as np
 import torch
@@ -47,6 +47,7 @@ from sglang.srt.disaggregation.utils import (
     setup_state_kv_args,
 )
 from sglang.srt.environ import envs
+from sglang.srt.managers.io_struct import AbortReq
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
     FINISH_LENGTH,
@@ -133,6 +134,7 @@ class PrefillBootstrapQueue:
         self.gpu_id = gpu_id
         self.bootstrap_port = bootstrap_port
         self.queue: List[Req] = []
+        self.pending_queue: Deque[Req] = deque()
         self.gloo_group = gloo_group
         self.scheduler = scheduler
         self.max_total_num_tokens = (
@@ -158,6 +160,7 @@ class PrefillBootstrapQueue:
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()
         )
+        kv_args.target_kv_data_ptr_count = len(kv_data_ptrs)
 
         if self.draft_token_to_kv_pool is not None:
             # We should also transfer draft model kv cache. The indices are
@@ -225,12 +228,37 @@ class PrefillBootstrapQueue:
                 )
         return kv_manager
 
-    def create_sender(self, req: Req, num_kv_heads: int) -> bool:
-        """Create a KV sender for the request without enqueuing it.
-        Returns False if the request exceeds KV capacity."""
-        if self._check_if_req_exceed_kv_capacity(req):
-            return False
+    def _active_sender_req_count(self) -> int:
+        """Count requests that already own a prefill KV sender.
 
+        Requests without a sender have not entered Mooncake's bootstrapping
+        state yet, so they do not consume metadata buffers and cannot hit the
+        fixed bootstrap timeout.
+        """
+        active_rids = set()
+        queues = [
+            self.queue,
+            self.scheduler.waiting_queue,
+            getattr(self.scheduler, "disagg_prefill_inflight_queue", []),
+        ]
+        for batch_name in ("cur_batch", "last_batch", "running_batch"):
+            batch = getattr(self.scheduler, batch_name, None)
+            if batch is not None:
+                queues.append(getattr(batch, "reqs", []))
+
+        for reqs in queues:
+            for req in reqs:
+                if getattr(req, "disagg_kv_sender", None) is not None:
+                    active_rids.add(req.rid)
+        return len(active_rids)
+
+    def _max_active_sender_reqs(self) -> int:
+        return self.req_to_metadata_buffer_idx_allocator.size
+
+    def _can_admit_sender(self) -> bool:
+        return self._active_sender_req_count() < self._max_active_sender_reqs()
+
+    def _create_kv_sender(self, req: Req, num_kv_heads: int) -> None:
         backend = (
             TransferBackend.FAKE
             if req.bootstrap_host == FAKE_BOOTSTRAP_HOST
@@ -247,9 +275,8 @@ class PrefillBootstrapQueue:
             dest_tp_ranks=dest_tp_ranks,
             pp_rank=self.pp_rank,
         )
-        self._process_req(req)
         req.pending_bootstrap = True
-        return True
+        self.queue.append(req)
 
     def ensure_metadata_buffer(self, req: Req) -> bool:
         if req.metadata_buffer_index >= 0:
@@ -281,10 +308,21 @@ class PrefillBootstrapQueue:
         req.pending_bootstrap = False
         return True
 
+    def _admit_pending(self, num_kv_heads: int) -> None:
+        while self.pending_queue and self._can_admit_sender():
+            req = self.pending_queue.popleft()
+            if isinstance(req.finished_reason, FINISH_ABORT):
+                self.scheduler.output_streamer.stream_output([req], req.return_logprob)
+                continue
+            self._create_kv_sender(req, num_kv_heads)
+
     def add(self, req: Req, num_kv_heads: int) -> None:
-        if not self.create_sender(req, num_kv_heads):
+        if self._check_if_req_exceed_kv_capacity(req):
             return
-        self.queue.append(req)
+
+        self._process_req(req)
+        self.pending_queue.append(req)
+        self._admit_pending(num_kv_heads)
 
     def extend(self, reqs: List[Req], num_kv_heads: int) -> None:
         for req in reqs:
@@ -321,6 +359,8 @@ class PrefillBootstrapQueue:
         bootstrapped_reqs = []
         failed_reqs = []
         indices_to_remove = set()
+
+        self._admit_pending(self.scheduler.model_config.num_key_value_heads)
 
         if len(self.queue) == 0:
             if return_failed_reqs is False:
@@ -579,6 +619,22 @@ class SchedulerDisaggregationPrefillMixin:
         for i, (req, next_token_id) in enumerate(
             zip(batch.reqs, next_token_ids, strict=True)
         ):
+            if isinstance(getattr(req, "to_finish", None), FINISH_ABORT) or isinstance(
+                req.finished_reason, FINISH_ABORT
+            ):
+                if hasattr(req.disagg_kv_sender, "abort"):
+                    req.disagg_kv_sender.abort()
+                if hasattr(req.disagg_kv_sender, "clear"):
+                    req.disagg_kv_sender.clear()
+                release_kv_cache(req, self.tree_cache, is_insert=False)
+                maybe_release_metadata_buffer(
+                    req, self.req_to_metadata_buffer_idx_allocator
+                )
+                self.ipc_channels.send_to_tokenizer.send_output(
+                    AbortReq(rid=req.rid), req
+                )
+                continue
+
             if req.inflight_middle_chunks <= 0:
                 req.time_stats.set_prefill_finished_time()
 

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1071,17 +1071,16 @@ class DeepseekSparseAttnBackend(
                 page_indices, repeats=self.speculative_num_draft_tokens, dim=0
             )
             metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
-            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * bs
-
-            seqlens_expanded = seqlens_expand_triton(
-                torch.tensor(
-                    extend_seq_lens_cpu, dtype=torch.int32, device=self.device
-                ),
-                cache_seqlens,
-                self.speculative_num_draft_tokens * bs,
-                self.speculative_num_draft_tokens,
+            # Compute seqlens_expanded in-place to avoid allocations that
+            # conflict with the CUDA graph memory pool.
+            # seqlens_expanded[i*draft_tokens+j] = cache_seqlens[i] - draft_tokens + 1 + j
+            draft_tokens = self.speculative_num_draft_tokens
+            total_len = draft_tokens * bs
+            metadata.dsa_seqlens_expanded[:total_len].view(bs, draft_tokens).copy_(
+                (cache_seqlens - draft_tokens + 1).unsqueeze(1)
+                + self.get_device_int32_arange(draft_tokens).unsqueeze(0)
             )
-            metadata.dsa_seqlens_expanded.copy_(seqlens_expanded)
+            seqlens_expanded = metadata.dsa_seqlens_expanded[:total_len]
             dsa_cache_seqlens = compute_dsa_seqlens(
                 seqlens_expanded, self.dsa_index_topk
             )
@@ -1479,12 +1478,34 @@ class DeepseekSparseAttnBackend(
                     page_size=1,
                 )
 
-        # todo hisparse: to cover more backends
         if self.hisparse_coordinator is not None:
-            # flash_mla_sparse_fwd / tilelang require int32 page indices.
-            page_table_1 = self.token_to_kv_pool.translate_loc_to_hisparse_device(
-                page_table_1
-            ).to(torch.int32)
+            if forward_batch.forward_mode.is_target_verify():
+                num_reqs = forward_batch.req_pool_indices.shape[0]
+                num_steps = self.speculative_num_draft_tokens
+                assert (
+                    topk_indices is not None
+                ), "topk_indices is None in TARGET_VERIFY/DRAFT_EXTEND_V2"
+                assert topk_indices.shape == (
+                    num_reqs * num_steps,
+                    self.dsa_index_topk,
+                ), (
+                    f"topk_indices shape mismatch: {topk_indices.shape} vs expected "
+                    f"({num_reqs * num_steps}, {self.dsa_index_topk}), "
+                    f"forward_mode={forward_batch.forward_mode}, num_reqs={num_reqs}, num_steps={num_steps}"
+                )
+                page_table_1 = self.hisparse_coordinator.swap_in_selected_pages(
+                    forward_batch.req_pool_indices,
+                    metadata.dsa_seqlens_expanded,
+                    topk_indices.view(num_reqs, num_steps, -1),
+                    layer.layer_id,
+                    token_position_space="full",
+                    num_steps=num_steps,
+                ).view(num_reqs * num_steps, -1)
+            else:
+                # flash_mla_sparse_fwd / tilelang require int32 page indices.
+                page_table_1 = self.token_to_kv_pool.translate_loc_to_hisparse_device(
+                    page_table_1
+                ).to(torch.int32)
 
         if dsa_impl == "tilelang":
             if q_rope is not None:
@@ -1643,6 +1664,7 @@ class DeepseekSparseAttnBackend(
                 forward_batch.seq_lens,
                 topk_indices,
                 layer.layer_id,
+                token_position_space="full",
             )
         elif envs.SGLANG_DSA_FUSE_TOPK.get():
             page_table_1 = self._get_fused_topk_page_table(topk_indices)
@@ -2304,9 +2326,9 @@ class DeepseekSparseAttnBackend(
     def get_indexer_metadata(
         self, layer_id: int, forward_batch: ForwardBatch
     ) -> DSAIndexerMetadata:
-        force_unfused = (
-            self.hisparse_coordinator is not None
-            and forward_batch.forward_mode.is_decode_or_idle()
+        force_unfused = self.hisparse_coordinator is not None and (
+            forward_batch.forward_mode.is_decode_or_idle()
+            or forward_batch.forward_mode.is_target_verify()
         )
         return DSAIndexerMetadata(
             attn_metadata=self.forward_metadata,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1514,7 +1514,7 @@ class DeepseekSparseAttnBackend(
                     token_position_space="full",
                     num_steps=num_steps,
                 ).view(num_reqs * num_steps, -1)
-            elif forward_batch.forward_mode.is_draft_extend(include_v2=True):
+            elif forward_batch.forward_mode.is_draft_extend_v2():
                 assert (
                     topk_indices is not None
                 ), "topk_indices is None in DRAFT_EXTEND/DRAFT_EXTEND_V2"
@@ -2445,7 +2445,7 @@ class DeepseekSparseAttnBackend(
         ) and (
             forward_batch.forward_mode.is_decode_or_idle()
             or forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend(include_v2=True)
+            or forward_batch.forward_mode.is_draft_extend_v2()
         )
         return DSAIndexerMetadata(
             attn_metadata=self.forward_metadata,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -95,6 +95,11 @@ def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tens
     return seqlens_32.contiguous().view(-1, 1)
 
 
+def _uses_hisparse_device_mapping(token_to_kv_pool) -> bool:
+    translate_loc = getattr(token_to_kv_pool, "translate_loc_to_hisparse_device", None)
+    return callable(translate_loc)
+
+
 # Reuse this workspace buffer across all DSA backend instances
 global_workspace_buffer = None
 
@@ -1454,6 +1459,14 @@ class DeepseekSparseAttnBackend(
         topk_transform_method = self.get_topk_transform_method(
             forward_batch.forward_mode
         )
+        hisparse_coordinator = (
+            getattr(forward_batch, "hisparse_coordinator", None)
+            or self.hisparse_coordinator
+        )
+        use_device_mapping_without_coordinator = (
+            hisparse_coordinator is None
+            and _uses_hisparse_device_mapping(self.token_to_kv_pool)
+        )
         if envs.SGLANG_DSA_FUSE_TOPK.get():
             page_table_1 = self._get_fused_topk_page_table(topk_indices)
         else:
@@ -1478,7 +1491,7 @@ class DeepseekSparseAttnBackend(
                     page_size=1,
                 )
 
-        if self.hisparse_coordinator is not None:
+        if hisparse_coordinator is not None:
             if forward_batch.forward_mode.is_target_verify():
                 num_reqs = forward_batch.req_pool_indices.shape[0]
                 num_steps = self.speculative_num_draft_tokens
@@ -1493,7 +1506,7 @@ class DeepseekSparseAttnBackend(
                     f"({num_reqs * num_steps}, {self.dsa_index_topk}), "
                     f"forward_mode={forward_batch.forward_mode}, num_reqs={num_reqs}, num_steps={num_steps}"
                 )
-                page_table_1 = self.hisparse_coordinator.swap_in_selected_pages(
+                page_table_1 = hisparse_coordinator.swap_in_selected_pages(
                     forward_batch.req_pool_indices,
                     metadata.dsa_seqlens_expanded,
                     topk_indices.view(num_reqs, num_steps, -1),
@@ -1501,11 +1514,26 @@ class DeepseekSparseAttnBackend(
                     token_position_space="full",
                     num_steps=num_steps,
                 ).view(num_reqs * num_steps, -1)
+            elif forward_batch.forward_mode.is_draft_extend(include_v2=True):
+                assert (
+                    topk_indices is not None
+                ), "topk_indices is None in DRAFT_EXTEND/DRAFT_EXTEND_V2"
+                page_table_1 = self._swap_in_hisparse_draft_extend_pages(
+                    forward_batch,
+                    metadata,
+                    topk_indices,
+                    layer.layer_id,
+                    hisparse_coordinator,
+                )
             else:
                 # flash_mla_sparse_fwd / tilelang require int32 page indices.
                 page_table_1 = self.token_to_kv_pool.translate_loc_to_hisparse_device(
                     page_table_1
                 ).to(torch.int32)
+        elif use_device_mapping_without_coordinator:
+            page_table_1 = self.token_to_kv_pool.translate_loc_to_hisparse_device(
+                page_table_1
+            ).to(torch.int32)
 
         if dsa_impl == "tilelang":
             if q_rope is not None:
@@ -1658,8 +1686,16 @@ class DeepseekSparseAttnBackend(
         if topk_indices is not None:
             topk_indices = self._pad_topk_indices(topk_indices, q_nope.shape[0])
 
-        if self.hisparse_coordinator is not None:
-            page_table_1 = self.hisparse_coordinator.swap_in_selected_pages(
+        hisparse_coordinator = (
+            getattr(forward_batch, "hisparse_coordinator", None)
+            or self.hisparse_coordinator
+        )
+        use_device_mapping_without_coordinator = (
+            hisparse_coordinator is None
+            and _uses_hisparse_device_mapping(self.token_to_kv_pool)
+        )
+        if hisparse_coordinator is not None:
+            page_table_1 = hisparse_coordinator.swap_in_selected_pages(
                 forward_batch.req_pool_indices,
                 forward_batch.seq_lens,
                 topk_indices,
@@ -1674,6 +1710,11 @@ class DeepseekSparseAttnBackend(
                 topk_indices=topk_indices,
                 page_size=1,
             )
+
+        if use_device_mapping_without_coordinator:
+            page_table_1 = self.token_to_kv_pool.translate_loc_to_hisparse_device(
+                page_table_1
+            ).to(torch.int32)
 
         if self.dsa_decode_impl == "flashmla_sparse":
             if q_rope is not None:
@@ -2223,6 +2264,78 @@ class DeepseekSparseAttnBackend(
 
         return out
 
+    def _swap_in_hisparse_draft_extend_pages(
+        self,
+        forward_batch: ForwardBatch,
+        metadata: DSAMetadata,
+        topk_indices: torch.Tensor,
+        layer_id: int,
+        hisparse_coordinator,
+    ) -> torch.Tensor:
+        """Swap HiSparse pages for variable-length DRAFT_EXTEND queries."""
+        extend_lens_cpu = forward_batch.extend_seq_lens_cpu
+        if extend_lens_cpu is None:
+            extend_lens_cpu = metadata.dsa_extend_seq_lens_list
+        extend_lens_cpu = [int(x) for x in extend_lens_cpu]
+
+        num_reqs = forward_batch.req_pool_indices.shape[0]
+        extend_lens_cpu = extend_lens_cpu[:num_reqs]
+        total_extend = sum(extend_lens_cpu)
+        if total_extend == 0:
+            return topk_indices.new_full(topk_indices.shape, -1)
+
+        max_steps = max(extend_lens_cpu)
+        if max_steps == 0:
+            return topk_indices.new_full(topk_indices.shape, -1)
+
+        real_topk = topk_indices[:total_extend]
+        padded_topk = topk_indices.new_full(
+            (num_reqs, max_steps, topk_indices.shape[-1]), -1
+        )
+        padded_seq_lens = metadata.dsa_seqlens_expanded.new_ones((num_reqs, max_steps))
+
+        offset = 0
+        for req_idx, extend_len in enumerate(extend_lens_cpu):
+            if extend_len == 0:
+                continue
+            next_offset = offset + extend_len
+            padded_topk[req_idx, :extend_len].copy_(real_topk[offset:next_offset])
+            padded_seq_lens[req_idx, :extend_len].copy_(
+                metadata.dsa_seqlens_expanded[offset:next_offset]
+            )
+            offset = next_offset
+
+        swapped = hisparse_coordinator.swap_in_selected_pages(
+            forward_batch.req_pool_indices,
+            padded_seq_lens.reshape(-1),
+            padded_topk,
+            layer_id,
+            token_position_space="full",
+            num_steps=max_steps,
+        )
+
+        rows = [
+            swapped[req_idx, :extend_len]
+            for req_idx, extend_len in enumerate(extend_lens_cpu)
+            if extend_len > 0
+        ]
+        page_table_1 = torch.cat(rows, dim=0)
+        if topk_indices.shape[0] > total_extend:
+            page_table_1 = torch.cat(
+                [
+                    page_table_1,
+                    topk_indices.new_full(
+                        (
+                            topk_indices.shape[0] - total_extend,
+                            topk_indices.shape[-1],
+                        ),
+                        -1,
+                    ),
+                ],
+                dim=0,
+            )
+        return page_table_1
+
     def _pad_topk_indices(
         self, topk_indices: torch.Tensor, num_tokens: int
     ) -> torch.Tensor:
@@ -2326,9 +2439,13 @@ class DeepseekSparseAttnBackend(
     def get_indexer_metadata(
         self, layer_id: int, forward_batch: ForwardBatch
     ) -> DSAIndexerMetadata:
-        force_unfused = self.hisparse_coordinator is not None and (
+        force_unfused = (
+            (self.hisparse_coordinator is not None)
+            or (getattr(forward_batch, "hisparse_coordinator", None) is not None)
+        ) and (
             forward_batch.forward_mode.is_decode_or_idle()
             or forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend(include_v2=True)
         )
         return DSAIndexerMetadata(
             attn_metadata=self.forward_metadata,

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -1,7 +1,7 @@
 # to be combined with the sparse coordinator class and sparse algorithm family
 
 import logging
-from typing import List, NamedTuple, Union
+from typing import List, Literal, NamedTuple, Union
 
 import torch
 
@@ -56,6 +56,7 @@ class HiSparseCoordinator:
         device: str,
         tp_group,
         host_to_device_ratio: int = 2,
+        host_allocator_type: str = "default",
     ):
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
@@ -100,6 +101,7 @@ class HiSparseCoordinator:
                 host_size=0,
                 page_size=self.mem_pool_device.page_size,
                 layout="layer_first",
+                allocator_type=host_allocator_type,
                 override_kv_cache_dim=self.mem_pool_device.kv_cache_dim,
             )
             self.item_size_bytes = self.mem_pool_host.token_stride_size
@@ -167,7 +169,7 @@ class HiSparseCoordinator:
             .contiguous()
         )
         self._device_buffer_arange_i32 = torch.arange(
-            self.device_buffer_size, dtype=torch.int32, device=device
+            self.padded_buffer_size, dtype=torch.int32, device=device
         )
 
         # Pre-allocated output buffer for swap_in_selected_pages (CUDA-graph safe)
@@ -340,7 +342,7 @@ class HiSparseCoordinator:
 
         self.req_device_buffer_tokens[
             :, req.req_pool_idx, : self.device_buffer_size
-        ] = self._device_buffer_arange_i32
+        ] = self._device_buffer_arange_i32[: self.device_buffer_size]
         self.req_device_buffer_token_locs[:, req.req_pool_idx, :alloc_size] = (
             buffer_indices[:alloc_size]
         )
@@ -410,6 +412,13 @@ class HiSparseCoordinator:
                     chunk = all_new_indices[offset : offset + grow_size]
                     offset += grow_size
                     self.req_to_device_buffer[req_idx, current_cap:new_cap] = chunk
+                    hot_end = min(new_cap, self.device_buffer_size)
+                    if current_cap < hot_end:
+                        self.req_device_buffer_tokens[
+                            :, req_idx, current_cap:hot_end
+                        ] = self._device_buffer_arange_i32[current_cap:hot_end]
+                    if hot_end < new_cap:
+                        self.req_device_buffer_tokens[:, req_idx, hot_end:new_cap] = -1
                     self.req_device_buffer_token_locs[
                         :, req_idx, current_cap:new_cap
                     ] = chunk
@@ -604,6 +613,417 @@ class HiSparseCoordinator:
         self._backup_done_event.wait(device_module.current_stream())
         self._has_pending_backup = False
 
+    def supports_hisparse_draft_slots(self) -> bool:
+        return not self.is_dsv4_hisparse
+
+    def _ensure_padded_buffer(self, req_pool_indices: torch.Tensor) -> None:
+        """Grow under-sized buffers to padded_buffer_size so extra-page slots are valid."""
+        req_indices_cpu = req_pool_indices.cpu().tolist()
+        grow_reqs = []
+        total_grow = 0
+        for req_idx in req_indices_cpu:
+            current_cap = int(self.req_device_buffer_size[req_idx])
+            if current_cap >= self.padded_buffer_size:
+                continue
+            grow_reqs.append((req_idx, current_cap))
+            total_grow += self.padded_buffer_size - current_cap
+
+        if total_grow == 0:
+            return
+
+        all_new = self.token_to_kv_pool_allocator.hisparse_attn_allocator.alloc(
+            total_grow
+        )
+        if all_new is None:
+            raise RuntimeError(
+                f"HiSparse: failed to grow buffers for draft slots (need {total_grow})"
+            )
+
+        offset = 0
+        for req_idx, current_cap in grow_reqs:
+            grow_size = self.padded_buffer_size - current_cap
+            chunk = all_new[offset : offset + grow_size]
+            offset += grow_size
+            self.req_to_device_buffer[
+                req_idx, current_cap : self.padded_buffer_size
+            ] = chunk
+            hot_end = min(self.padded_buffer_size, self.device_buffer_size)
+            if current_cap < hot_end:
+                self.req_device_buffer_tokens[:, req_idx, current_cap:hot_end] = (
+                    self._device_buffer_arange_i32[current_cap:hot_end]
+                )
+            if hot_end < self.padded_buffer_size:
+                self.req_device_buffer_tokens[
+                    :, req_idx, hot_end : self.padded_buffer_size
+                ] = -1
+            self.req_device_buffer_token_locs[
+                :, req_idx, current_cap : self.padded_buffer_size
+            ] = chunk
+            self.req_device_buffer_size[req_idx] = self.padded_buffer_size
+
+    def get_draft_device_slots(
+        self,
+        req_pool_indices: torch.Tensor,
+        num_tokens_per_req: int,
+        start_positions_cpu: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return device slots for a uniform draft allocation.
+
+        Draft tokens that still fit in the hot buffer reuse their logical hot
+        slots. Later draft tokens use the per-request extra-page area.
+        """
+        assert self.supports_hisparse_draft_slots()
+        start = self.device_buffer_size + 1
+        end = start + num_tokens_per_req
+        if end > self.padded_buffer_size:
+            raise ValueError(
+                f"Requested {num_tokens_per_req} draft slots but extra page only "
+                f"has {self.padded_buffer_size - self.device_buffer_size - 1} "
+                f"available (padded_buffer_size={self.padded_buffer_size}, "
+                f"device_buffer_size={self.device_buffer_size})."
+            )
+        self._ensure_padded_buffer(req_pool_indices)
+        self.req_device_buffer_tokens[
+            :, req_pool_indices, start : self.padded_buffer_size
+        ] = -1
+
+        total_slots = req_pool_indices.numel() * num_tokens_per_req
+        row_indices = torch.repeat_interleave(req_pool_indices, num_tokens_per_req)
+        pos_in_segment = torch.arange(total_slots, device=req_pool_indices.device) % (
+            num_tokens_per_req
+        )
+        start_positions = start_positions_cpu.to(
+            device=req_pool_indices.device, dtype=torch.int64
+        )
+        token_positions = (
+            torch.repeat_interleave(start_positions, num_tokens_per_req)
+            + pos_in_segment
+        )
+        col_indices = torch.where(
+            token_positions < self.device_buffer_size,
+            token_positions,
+            start + pos_in_segment,
+        )
+        if torch.any(col_indices >= self.padded_buffer_size):
+            raise ValueError(
+                "HiSparse draft slots exceed padded buffer: "
+                f"{col_indices.max().item()=} {self.padded_buffer_size=}"
+            )
+        self.req_device_buffer_tokens[:, row_indices, col_indices] = token_positions.to(
+            torch.int32
+        ).unsqueeze(0)
+        return self.req_to_device_buffer[row_indices, col_indices]
+
+    def get_draft_device_slots_variable(
+        self,
+        req_pool_indices: torch.Tensor,
+        tokens_per_req_cpu: torch.Tensor,
+        start_positions_cpu: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return device slots when each request needs a different draft count."""
+        assert self.supports_hisparse_draft_slots()
+        if tokens_per_req_cpu.numel() == 0:
+            return torch.empty(0, dtype=torch.int64, device=req_pool_indices.device)
+
+        start = self.device_buffer_size + 1
+        max_tokens = int(tokens_per_req_cpu.max().item())
+        if start + max_tokens > self.padded_buffer_size:
+            raise ValueError(
+                f"Max per-request draft slots ({max_tokens}) exceeds extra page "
+                f"capacity ({self.padded_buffer_size - self.device_buffer_size - 1})."
+            )
+
+        self._ensure_padded_buffer(req_pool_indices)
+        self.req_device_buffer_tokens[
+            :, req_pool_indices, start : self.padded_buffer_size
+        ] = -1
+
+        total_slots = int(tokens_per_req_cpu.sum().item())
+        if total_slots == 0:
+            return torch.empty(0, dtype=torch.int64, device=req_pool_indices.device)
+
+        tokens_per_req = tokens_per_req_cpu.to(
+            device=req_pool_indices.device, dtype=torch.int64
+        )
+
+        # Build fixed-shape gather indices. Zero-repeat requests naturally disappear.
+        row_indices = torch.repeat_interleave(req_pool_indices, tokens_per_req)
+        offsets = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.int64, device=tokens_per_req.device),
+                tokens_per_req.cumsum(0),
+            ]
+        )
+        pos_in_segment = torch.arange(total_slots, device=tokens_per_req.device) - (
+            torch.repeat_interleave(offsets[:-1], tokens_per_req)
+        )
+
+        start_positions = start_positions_cpu.to(
+            device=req_pool_indices.device, dtype=torch.int64
+        )
+        token_positions = torch.repeat_interleave(start_positions, tokens_per_req) + (
+            pos_in_segment
+        )
+        col_indices = torch.where(
+            token_positions < self.device_buffer_size,
+            token_positions,
+            start + pos_in_segment,
+        )
+        if torch.any(col_indices >= self.padded_buffer_size):
+            raise ValueError(
+                "HiSparse variable draft slots exceed padded buffer: "
+                f"{col_indices.max().item()=} {self.padded_buffer_size=}"
+            )
+
+        self.req_device_buffer_tokens[:, row_indices, col_indices] = token_positions.to(
+            torch.int32
+        ).unsqueeze(0)
+        return self.req_to_device_buffer[row_indices, col_indices]
+
+    def prepare_verify_slots_spec_v2(
+        self,
+        req_pool_indices: torch.Tensor,
+        verify_cache_locs: torch.Tensor,
+        num_tokens_per_req: int,
+        start_positions_cpu: torch.Tensor,
+    ) -> None:
+        """Bind the current spec-v2 target-verify window to extra-page slots."""
+        assert self.supports_hisparse_draft_slots()
+        start = self.device_buffer_size + 1
+        end = start + num_tokens_per_req
+        if end > self.padded_buffer_size:
+            raise ValueError(
+                f"Spec-v2 verify needs {num_tokens_per_req} slots but extra page only "
+                f"has {self.padded_buffer_size - self.device_buffer_size - 1}."
+            )
+
+        self._ensure_padded_buffer(req_pool_indices)
+        self.req_device_buffer_tokens[
+            :, req_pool_indices, start : self.padded_buffer_size
+        ] = -1
+
+        total_slots = req_pool_indices.numel() * num_tokens_per_req
+        if verify_cache_locs.numel() != total_slots:
+            raise ValueError(
+                "HiSparse spec-v2 verify slot mismatch: "
+                f"expected {total_slots} cache locs, got {verify_cache_locs.numel()}."
+            )
+
+        row_indices = torch.repeat_interleave(req_pool_indices, num_tokens_per_req)
+        pos_in_segment = torch.arange(total_slots, device=req_pool_indices.device) % (
+            num_tokens_per_req
+        )
+        start_positions = start_positions_cpu.to(
+            device=req_pool_indices.device, dtype=torch.int64
+        )
+        token_positions = (
+            torch.repeat_interleave(start_positions, num_tokens_per_req)
+            + pos_in_segment
+        )
+        col_indices = torch.where(
+            token_positions < self.device_buffer_size,
+            token_positions,
+            start + pos_in_segment,
+        )
+        device_slots = self.req_to_device_buffer[row_indices, col_indices]
+        self.req_device_buffer_tokens[:, row_indices, col_indices] = token_positions.to(
+            torch.int32
+        ).unsqueeze(0)
+        self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping[
+            verify_cache_locs
+        ] = device_slots
+
+    def finalize_accepted_tokens(
+        self,
+        req_pool_indices: torch.Tensor,
+        accepted_cache_locs: torch.Tensor,
+        draft_cache_locs: torch.Tensor,
+        num_correct_drafts: torch.Tensor,
+        num_correct_drafts_cpu: torch.Tensor,
+        accepted_token_positions: torch.Tensor,
+    ) -> None:
+        """Persist accepted speculative tokens and remap the newest token slot.
+
+        Accepted draft tokens inside the hot buffer keep their hot slots. Tokens
+        beyond the hot buffer are backed up to host, while the last accepted
+        token is copied into the newest-token slot for the next decode step.
+
+        Transactional: if host alloc fails, all mapping mutations are rolled back
+        so the coordinator stays consistent for the next iteration.
+        """
+        assert self.supports_hisparse_draft_slots()
+        if accepted_cache_locs.numel() == 0:
+            return
+
+        counts = num_correct_drafts.to(torch.int64) + 1
+        counts_cpu = num_correct_drafts_cpu.to(torch.int64) + 1
+        total_accepted = int(counts_cpu.sum().item())
+        if total_accepted != accepted_cache_locs.numel():
+            raise ValueError(
+                "HiSparse accepted token bookkeeping mismatch: "
+                f"expected {total_accepted} cache locs, got {accepted_cache_locs.numel()}."
+            )
+        if total_accepted != accepted_token_positions.numel():
+            raise ValueError(
+                "HiSparse accepted token position mismatch: "
+                f"expected {total_accepted} positions, "
+                f"got {accepted_token_positions.numel()}."
+            )
+
+        full_to_device_mapping = (
+            self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+        )
+        accepted_token_positions = accepted_token_positions.to(
+            device=accepted_cache_locs.device, dtype=torch.int64
+        )
+        in_hot_buffer = accepted_token_positions < self.device_buffer_size
+
+        # Snapshot mapping values before mutation for rollback.
+        draft_mapping_snapshot = full_to_device_mapping[draft_cache_locs].clone()
+        accepted_device_locs = full_to_device_mapping[accepted_cache_locs].clone()
+
+        full_to_device_mapping[draft_cache_locs] = 0
+        accepted_req_indices = torch.repeat_interleave(req_pool_indices, counts)
+        if torch.any(in_hot_buffer):
+            hot_cache_locs = accepted_cache_locs[in_hot_buffer]
+            hot_positions = accepted_token_positions[in_hot_buffer]
+            hot_req_indices = accepted_req_indices[in_hot_buffer]
+            hot_slots = self.req_to_device_buffer[hot_req_indices, hot_positions]
+            full_to_device_mapping[hot_cache_locs] = hot_slots
+
+        needs_backup = ~in_hot_buffer
+        backup_count = int(needs_backup.sum().item())
+        if backup_count > 0:
+            backup_positions = accepted_token_positions[needs_backup]
+            backup_req_indices = accepted_req_indices[needs_backup]
+            backup_device_locs = accepted_device_locs[needs_backup]
+
+            host_locs = self.mem_pool_host.alloc(backup_count)
+            if host_locs is None:
+                full_to_device_mapping[draft_cache_locs] = draft_mapping_snapshot
+                logger.error(
+                    "HiSparse: host alloc failed for %d accepted draft tokens, rolled back",
+                    backup_count,
+                )
+                return
+            host_locs = host_locs.to(device=self.device)
+
+            self.wait_for_pending_backup()
+            schedule_stream = device_module.current_stream()
+            device_locs_for_backup = backup_device_locs.contiguous()
+            with device_module.stream(self.decode_backup_stream):
+                self.decode_backup_stream.wait_stream(schedule_stream)
+                self.mem_pool_host.backup_from_device_all_layer(
+                    self.mem_pool_device,
+                    host_locs,
+                    device_locs_for_backup,
+                    io_backend="kernel",
+                )
+                if host_locs.is_cuda:
+                    host_locs.record_stream(self.decode_backup_stream)
+                if device_locs_for_backup.is_cuda:
+                    device_locs_for_backup.record_stream(self.decode_backup_stream)
+            event = device_module.Event()
+            event.record(self.decode_backup_stream)
+            device_module.current_stream().wait_event(event)
+
+            self.req_to_host_pool[backup_req_indices, backup_positions] = host_locs
+
+        offsets = torch.cat(
+            [torch.zeros(1, dtype=torch.int64, device=counts.device), counts.cumsum(0)]
+        )
+        last_offsets = offsets[1:] - 1
+        last_positions = accepted_token_positions[last_offsets]
+        newest_slots = self.req_to_device_buffer[
+            req_pool_indices, self.device_buffer_size
+        ]
+        last_logical = accepted_cache_locs[last_offsets]
+        last_slots = accepted_device_locs[last_offsets]
+        self.req_device_buffer_tokens[:, req_pool_indices, self.device_buffer_size] = (
+            last_positions.to(torch.int32).unsqueeze(0)
+        )
+        self.req_device_buffer_token_locs[
+            :, req_pool_indices, self.device_buffer_size
+        ] = newest_slots.to(torch.int32)
+        for idx in req_pool_indices.tolist():
+            self._skip_first_backup[idx] = True
+
+        same_slot = last_slots == newest_slots
+        if torch.any(~same_slot):
+            self.mem_pool_device.transfer_values_on_device(
+                dst_indices=newest_slots[~same_slot],
+                src_indices=last_slots[~same_slot],
+            )
+        full_to_device_mapping[last_logical] = newest_slots
+
+    def finalize_accepted_tokens_spec_v2(
+        self,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        verify_cache_locs: torch.Tensor,
+        accept_index: torch.Tensor,
+    ) -> None:
+        """Commit accepted spec-v2 target-verify KV into HiSparse storage.
+
+        The target verify pass writes all draft-token KV into per-request
+        extra-page slots. accept_index is the source of truth for which slots
+        survive into host/newest-slot metadata.
+        """
+        assert self.supports_hisparse_draft_slots()
+        if verify_cache_locs.numel() == 0:
+            return
+
+        counts = (accept_index != -1).sum(dim=1).to(torch.int64)
+        total_accepted = int(counts.sum().item())
+        if total_accepted == 0:
+            full_to_device_mapping = (
+                self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+            )
+            full_to_device_mapping[verify_cache_locs] = 0
+            return
+
+        flat_accept_index = accept_index.reshape(-1)
+        accepted_offsets = flat_accept_index[flat_accept_index >= 0].to(torch.int64)
+        if accepted_offsets.numel() != total_accepted:
+            raise ValueError(
+                "HiSparse spec-v2 accepted index mismatch: "
+                f"expected {total_accepted} accepted slots, "
+                f"got {accepted_offsets.numel()}."
+            )
+
+        offsets = torch.cat(
+            [torch.zeros(1, dtype=torch.int64, device=counts.device), counts.cumsum(0)]
+        )
+        pos_in_segment = torch.arange(
+            total_accepted, dtype=torch.int64, device=counts.device
+        ) - torch.repeat_interleave(offsets[:-1], counts)
+        accepted_token_positions = (
+            torch.repeat_interleave(seq_lens.to(torch.int64), counts) + pos_in_segment
+        )
+
+        self.finalize_accepted_tokens(
+            req_pool_indices=req_pool_indices,
+            accepted_cache_locs=verify_cache_locs[accepted_offsets],
+            draft_cache_locs=verify_cache_locs,
+            num_correct_drafts=counts - 1,
+            num_correct_drafts_cpu=(counts - 1).cpu(),
+            accepted_token_positions=accepted_token_positions,
+        )
+
+    def get_front_topk_tokens(
+        self,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> torch.Tensor:
+        top_k_indices = self.req_to_device_buffer[req_pool_indices, : self.top_k].to(
+            torch.int32
+        )
+        topk_col_indices = torch.arange(self.top_k, device=self.device).unsqueeze(0)
+        # Mask out positions beyond each request's seq_len
+        mask = topk_col_indices >= seq_lens.unsqueeze(1)
+        top_k_indices[mask] = -1
+        return top_k_indices
+
     def naive_load_topk(
         self,
         req_pool_indices: torch.Tensor,
@@ -788,14 +1208,65 @@ class HiSparseCoordinator:
         compressed_seq_lens: torch.Tensor,
         top_k_result: torch.Tensor,
         layer_id: int,
+        token_position_space: Literal["compressed", "full"] = "compressed",
+        num_steps: int = 1,
     ) -> torch.Tensor:
-        """Swap selected top-k tokens into device memory and return their indices."""
-        num_reqs = req_pool_indices.size(0)
+        """Swap selected top-k tokens into device memory and return their indices.
 
-        top_k_indices = self.top_k_device_locs_buffer[:num_reqs]
+        When num_steps > 1 (speculative multi-step):
+            seq_lens shape: [num_reqs * num_steps] flat req-major
+            top_k_result shape: [num_reqs, num_steps, top_k]
+            returns: [num_reqs, num_steps, top_k]
+        """
+        num_reqs = req_pool_indices.size(0)
+        needed = num_reqs * num_steps
+
+        if needed > self.top_k_device_locs_buffer.shape[0]:
+            self.top_k_device_locs_buffer = torch.full(
+                (needed, self.top_k),
+                -1,
+                dtype=torch.int32,
+                device=self.device,
+            )
+
+        if num_steps > 1:
+            top_k_indices = self.top_k_device_locs_buffer[:needed].view(
+                num_reqs, num_steps, -1
+            )
+        else:
+            top_k_indices = self.top_k_device_locs_buffer[:num_reqs]
         top_k_indices.fill_(-1)
 
-        # todo, adjustable for performance
+        swap_seq_lens = compressed_seq_lens
+        swap_top_k_result = top_k_result
+        if token_position_space == "full" and self.is_dsv4_hisparse:
+            if num_steps > 1:
+                seq_lens_for_compare = compressed_seq_lens.view(
+                    num_reqs, num_steps
+                ).unsqueeze(2)
+            else:
+                seq_lens_for_compare = compressed_seq_lens.unsqueeze(1)
+            valid_compressed_token = (
+                (top_k_result >= 0)
+                & (top_k_result < seq_lens_for_compare)
+                & ((top_k_result + 1) % self.compress_ratio == 0)
+            )
+            swap_top_k_result = torch.where(
+                valid_compressed_token,
+                top_k_result // self.compress_ratio,
+                torch.full_like(top_k_result, -1),
+            )
+            if num_steps > 1:
+                swap_seq_lens = (
+                    compressed_seq_lens.view(num_reqs, num_steps) // self.compress_ratio
+                ).reshape(-1)
+            else:
+                swap_seq_lens = compressed_seq_lens // self.compress_ratio
+        elif token_position_space != "compressed":
+            assert (
+                token_position_space == "full"
+            ), f"Unsupported token_position_space={token_position_space}"
+
         block_size = 1024
         swap_in_fn = (
             load_cache_to_device_buffer_dsv4_mla
@@ -803,7 +1274,7 @@ class HiSparseCoordinator:
             else load_cache_to_device_buffer_mla
         )
         swap_in_fn(
-            top_k_tokens=top_k_result,
+            top_k_tokens=swap_top_k_result,
             device_buffer_tokens=self.req_device_buffer_tokens[layer_id],
             host_cache_locs=self.req_to_host_pool,
             device_buffer_locs=self.req_device_buffer_token_locs[layer_id],
@@ -811,13 +1282,14 @@ class HiSparseCoordinator:
             device_buffer=self.mem_pool_device.kv_buffer[layer_id],
             top_k_device_locs=top_k_indices,
             req_pool_indices=req_pool_indices,
-            seq_lens=compressed_seq_lens,
+            seq_lens=swap_seq_lens,
             lru_slots=self.lru_slots[layer_id],
             item_size_bytes=self.item_size_bytes,
             num_top_k=self.top_k,
             hot_buffer_size=self.device_buffer_size,
-            page_size=1,
+            page_size=self.mem_pool_device.page_size if num_steps > 1 else 1,
             block_size=block_size,
             num_real_reqs=self.num_real_reqs,
+            num_steps=num_steps,
         )
         return top_k_indices

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -186,6 +186,7 @@ class HiSparseCoordinator:
         # CPU flag: True means "skip backup on the next decode step" because
         # staging already backed up all prefill tokens.  Cleared after one step.
         self._skip_first_backup = [False] * max_num_req_slots
+        self._pending_draft_extend_backup = None
 
     def set_decode_producer_stream(self, stream) -> None:
         self.decode_producer_stream = stream
@@ -479,6 +480,9 @@ class HiSparseCoordinator:
             self.req_device_buffer_token_locs[
                 :, req_pool_indices, self.device_buffer_size
             ] = reserved_buffer_loc.to(torch.int32)
+            self.req_device_buffer_tokens[
+                :, req_pool_indices, self.device_buffer_size
+            ] = (seq_lens.to(torch.int32) - 1)
 
             # No need to clear prior mappings: the only consumer of the mapping
             # for past tokens is the swap-in kernel, and it goes through
@@ -612,6 +616,57 @@ class HiSparseCoordinator:
             return
         self._backup_done_event.wait(device_module.current_stream())
         self._has_pending_backup = False
+
+    def _backup_device_locs_to_host(
+        self, host_locs: torch.Tensor, device_locs: torch.Tensor
+    ) -> None:
+        if host_locs.numel() == 0:
+            return
+        self.wait_for_pending_backup()
+        schedule_stream = device_module.current_stream()
+        device_locs = device_locs.contiguous()
+        with device_module.stream(self.decode_backup_stream):
+            self.decode_backup_stream.wait_stream(schedule_stream)
+            if self.decode_producer_stream is not None:
+                self.decode_backup_stream.wait_stream(self.decode_producer_stream)
+            self.mem_pool_host.backup_from_device_all_layer(
+                self.mem_pool_device,
+                host_locs,
+                device_locs,
+                io_backend="kernel",
+            )
+            if host_locs.is_cuda:
+                host_locs.record_stream(self.decode_backup_stream)
+            if device_locs.is_cuda:
+                device_locs.record_stream(self.decode_backup_stream)
+        event = device_module.Event()
+        event.record(self.decode_backup_stream)
+        device_module.current_stream().wait_event(event)
+
+    def finish_pending_draft_extend_backup(self) -> None:
+        pending = self._pending_draft_extend_backup
+        if pending is None:
+            return
+        self._pending_draft_extend_backup = None
+        host_locs, device_locs, logical_locs_to_clear = pending
+        self._backup_device_locs_to_host(host_locs, device_locs)
+        if logical_locs_to_clear.numel() > 0:
+            full_to_device_mapping = (
+                self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+            )
+            full_to_device_mapping[logical_locs_to_clear] = 0
+
+    def clear_pending_draft_extend_backup(self) -> None:
+        pending = self._pending_draft_extend_backup
+        if pending is None:
+            return
+        self._pending_draft_extend_backup = None
+        _, _, logical_locs_to_clear = pending
+        if logical_locs_to_clear.numel() > 0:
+            full_to_device_mapping = (
+                self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+            )
+            full_to_device_mapping[logical_locs_to_clear] = 0
 
     def supports_hisparse_draft_slots(self) -> bool:
         return not self.is_dsv4_hisparse
@@ -854,6 +909,7 @@ class HiSparseCoordinator:
         assert self.supports_hisparse_draft_slots()
         if accepted_cache_locs.numel() == 0:
             return
+        self.clear_pending_draft_extend_backup()
 
         counts = num_correct_drafts.to(torch.int64) + 1
         counts_cpu = num_correct_drafts_cpu.to(torch.int64) + 1
@@ -908,43 +964,27 @@ class HiSparseCoordinator:
                 return
             host_locs = host_locs.to(device=self.device)
 
-            self.wait_for_pending_backup()
-            schedule_stream = device_module.current_stream()
-            device_locs_for_backup = backup_device_locs.contiguous()
-            with device_module.stream(self.decode_backup_stream):
-                self.decode_backup_stream.wait_stream(schedule_stream)
-                self.mem_pool_host.backup_from_device_all_layer(
-                    self.mem_pool_device,
-                    host_locs,
-                    device_locs_for_backup,
-                    io_backend="kernel",
-                )
-                if host_locs.is_cuda:
-                    host_locs.record_stream(self.decode_backup_stream)
-                if device_locs_for_backup.is_cuda:
-                    device_locs_for_backup.record_stream(self.decode_backup_stream)
-            event = device_module.Event()
-            event.record(self.decode_backup_stream)
-            device_module.current_stream().wait_event(event)
-
+            self._backup_device_locs_to_host(host_locs, backup_device_locs)
             self.req_to_host_pool[backup_req_indices, backup_positions] = host_locs
+            full_to_device_mapping[accepted_cache_locs[needs_backup]] = (
+                backup_device_locs
+            )
 
         offsets = torch.cat(
             [torch.zeros(1, dtype=torch.int64, device=counts.device), counts.cumsum(0)]
         )
         last_offsets = offsets[1:] - 1
         last_positions = accepted_token_positions[last_offsets]
-        newest_slots = self.req_to_device_buffer[
-            req_pool_indices, self.device_buffer_size
-        ]
+        reserved_positions = last_positions.clamp(max=self.device_buffer_size)
+        newest_slots = self.req_to_device_buffer[req_pool_indices, reserved_positions]
         last_logical = accepted_cache_locs[last_offsets]
         last_slots = accepted_device_locs[last_offsets]
-        self.req_device_buffer_tokens[:, req_pool_indices, self.device_buffer_size] = (
+        self.req_device_buffer_tokens[:, req_pool_indices, reserved_positions] = (
             last_positions.to(torch.int32).unsqueeze(0)
         )
-        self.req_device_buffer_token_locs[
-            :, req_pool_indices, self.device_buffer_size
-        ] = newest_slots.to(torch.int32)
+        self.req_device_buffer_token_locs[:, req_pool_indices, reserved_positions] = (
+            newest_slots.to(torch.int32)
+        )
         for idx in req_pool_indices.tolist():
             self._skip_first_backup[idx] = True
 
@@ -955,6 +995,28 @@ class HiSparseCoordinator:
                 src_indices=last_slots[~same_slot],
             )
         full_to_device_mapping[last_logical] = newest_slots
+
+        if backup_count > 0:
+            backup_positions_in_needs = (
+                torch.cumsum(needs_backup.to(torch.int64), dim=0) - 1
+            )
+            last_needs_backup = needs_backup[last_offsets]
+            post_backup_device_locs = backup_device_locs.clone()
+            if torch.any(last_needs_backup):
+                last_backup_offsets = backup_positions_in_needs[
+                    last_offsets[last_needs_backup]
+                ]
+                post_backup_device_locs[last_backup_offsets] = newest_slots[
+                    last_needs_backup
+                ]
+
+            logical_locs_to_clear_mask = needs_backup.clone()
+            logical_locs_to_clear_mask[last_offsets] = False
+            self._pending_draft_extend_backup = (
+                host_locs,
+                post_backup_device_locs,
+                accepted_cache_locs[logical_locs_to_clear_mask],
+            )
 
     def finalize_accepted_tokens_spec_v2(
         self,

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -609,19 +609,22 @@ class HiSparseCoordinator:
 
         device_locs = self.req_to_device_buffer[backup_req_indices, buffer_slot]
 
-        host_locs_list = []
+        start_positions = []
         for i in backup_indices:
-            req_idx = int(req_pool_indices_cpu[i])
             start_pos = (int(seq_lens_cpu[i]) - 1) // self.compress_ratio - 1
-            host_locs = self.mem_pool_host.alloc_paged_token_slots(
-                self.req_to_host_pool,
-                self.req_to_host_pool_allocated_len,
-                req_idx,
-                start_pos,
-                1,
+            start_positions.append(start_pos)
+        host_locs = self._alloc_host_token_slots(len(start_positions))
+        if host_locs is None:
+            logger.error(
+                "HiSparse: host alloc failed for %d eager backup tokens",
+                len(start_positions),
             )
-            host_locs_list.append(host_locs)
-        host_locs = torch.cat(host_locs_list)
+            raise RuntimeError("HiSparse eager host backup allocation failed")
+        host_positions = torch.tensor(
+            start_positions, dtype=torch.int64, device=self.device
+        )
+        self.req_to_host_pool[backup_req_indices, host_positions] = host_locs
+        self._mark_host_positions_allocated(backup_req_indices, host_positions)
 
         self.wait_for_pending_backup()
         schedule_stream = device_module.current_stream()
@@ -989,7 +992,7 @@ class HiSparseCoordinator:
             backup_req_indices = accepted_req_indices[needs_backup]
             backup_device_locs = accepted_device_locs[needs_backup]
 
-            host_locs = self.mem_pool_host.alloc(backup_count)
+            host_locs = self._alloc_host_token_slots(backup_count)
             if host_locs is None:
                 full_to_device_mapping[draft_cache_locs] = draft_mapping_snapshot
                 logger.error(
@@ -997,10 +1000,10 @@ class HiSparseCoordinator:
                     backup_count,
                 )
                 return
-            host_locs = host_locs.to(device=self.device)
 
             self._backup_device_locs_to_host(host_locs, backup_device_locs)
             self.req_to_host_pool[backup_req_indices, backup_positions] = host_locs
+            self._mark_host_positions_allocated(backup_req_indices, backup_positions)
             full_to_device_mapping[accepted_cache_locs[needs_backup]] = (
                 backup_device_locs
             )
@@ -1289,6 +1292,34 @@ class HiSparseCoordinator:
         if host_indices.numel() > 0:
             self.mem_pool_host.free(host_indices)
 
+    def _alloc_host_token_slots(self, num_tokens: int) -> Union[torch.Tensor, None]:
+        if num_tokens <= 0:
+            return torch.empty((0,), dtype=torch.int64, device=self.device)
+
+        page_size = self.mem_pool_host.page_size
+        alloc_size = ((num_tokens + page_size - 1) // page_size) * page_size
+        host_indices = self.mem_pool_host.alloc(alloc_size)
+        if host_indices is None:
+            return None
+
+        host_indices = host_indices.to(device=self.device)
+        if host_indices.numel() > num_tokens:
+            self._free_host_indices(host_indices[num_tokens:])
+            host_indices = host_indices[:num_tokens]
+        return host_indices
+
+    def _mark_host_positions_allocated(
+        self, req_pool_indices: torch.Tensor, token_positions: torch.Tensor
+    ) -> None:
+        page_size = self.mem_pool_host.page_size
+        req_indices_cpu = req_pool_indices.detach().cpu().tolist()
+        positions_cpu = token_positions.detach().cpu().tolist()
+        for req_idx, token_position in zip(req_indices_cpu, positions_cpu):
+            page_end = ((int(token_position) + page_size) // page_size) * page_size
+            current_len = int(self.req_to_host_pool_allocated_len[req_idx])
+            if page_end > current_len:
+                self.req_to_host_pool_allocated_len[req_idx] = page_end
+
     @staticmethod
     def _req_pool_idx(req: Req) -> int:
         req_idx = req.req_pool_idx
@@ -1372,7 +1403,7 @@ class HiSparseCoordinator:
             )
             return False
 
-        new_host_indices = self.mem_pool_host.alloc(missing_positions.numel())
+        new_host_indices = self._alloc_host_token_slots(missing_positions.numel())
         if new_host_indices is None:
             logger.warning(
                 "HiSparse cannot retract req %s: host mem pool alloc failed for "
@@ -1382,9 +1413,10 @@ class HiSparseCoordinator:
                 self.mem_pool_host.available_size(),
             )
             return False
-        new_host_indices = new_host_indices.to(device=self.device)
         self._backup_device_locs_to_host(new_host_indices, device_locs)
         self.req_to_host_pool[req.req_pool_idx, missing_positions] = new_host_indices
+        req_indices = torch.full_like(missing_positions, req.req_pool_idx)
+        self._mark_host_positions_allocated(req_indices, missing_positions)
         return True
 
     def retract_req(self, req: Req) -> bool:

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -208,6 +208,41 @@ class HiSparseCoordinator:
             ),
         )
 
+    def compressed_host_len(self, full_len: int) -> int:
+        """Number of host slots needed for a committed full-token length."""
+        return max(0, full_len) // self.compress_ratio
+
+    def host_decode_reserve_len(self, full_len: int, num_decode_tokens: int) -> int:
+        """Extra host slots needed to keep decoding for `num_decode_tokens`."""
+        if num_decode_tokens <= 0:
+            return 0
+        return self.compressed_host_len(full_len + num_decode_tokens) - (
+            self.compressed_host_len(full_len)
+        )
+
+    def host_tokens_required_next_decode(
+        self, reqs: List[Req], speculative_token_budget: int = 0
+    ) -> int:
+        """Host slots that may be newly allocated by the next decode iteration.
+
+        `speculative_token_budget` is host-specific: it should cover accepted
+        draft tokens that may be backed up to host, not the full GPU draft KV
+        allocation used to run speculative verification.
+        """
+        required = 0
+        for req in reqs:
+            req_idx = self._req_pool_idx(req)
+            if self._skip_first_backup[req_idx]:
+                continue
+
+            seq_len = getattr(req, "kv_committed_len", None)
+            if seq_len is None:
+                seq_len = len(req.origin_input_ids) + len(req.output_ids)
+            if seq_len % self.compress_ratio == 0:
+                required += 1
+
+        return required + max(0, speculative_token_budget)
+
     def admit_request_into_staging(self, req: Req) -> None:
         req.hisparse_staging = True
 
@@ -1224,7 +1259,7 @@ class HiSparseCoordinator:
         # subsequent release_kv_cache -> allocator.free -> free_hisparse path
         # re-frees them (double-free into the page allocator's free list).
         allocated_len = req.kv_allocated_len
-        host_len = self.host_token_len(allocated_len)
+        host_len = self.compressed_host_len(allocated_len)
 
         # release memory -- only free actually-allocated buffer indices
         current_cap = int(self.req_device_buffer_size[req_idx])
@@ -1359,7 +1394,7 @@ class HiSparseCoordinator:
 
         preserve_len = len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
         req_idx = self._req_pool_idx(req)
-        host_len = self.host_token_len(preserve_len)
+        host_len = self.compressed_host_len(preserve_len)
         stale_host_indices = self.req_to_host_pool[req_idx, host_len:]
         self._free_host_indices(stale_host_indices)
         self.req_to_host_pool[req_idx, host_len:] = -1

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -1210,17 +1210,12 @@ class HiSparseCoordinator:
         self._skip_first_backup[req.req_pool_idx] = False
         req.hisparse_staging = False
 
-    def retract_req(self, req: Req) -> None:
-        if req.hisparse_staging:
-            self.abort_staging_request(req)
-        else:
-            self.request_finished(req)
-
-    def request_finished(self, req: Req):
+    def _clear_req_device_state(self, req: Req) -> int:
         # release resources only after the execution of a potential overlapped batch
         if self.decode_producer_stream is not None:
             device_module.current_stream().wait_stream(self.decode_producer_stream)
         self.wait_for_pending_backup()
+        req_idx = self._req_pool_idx(req)
 
         # Use kv_allocated_len (not seqlen): under speculative decoding the
         # allocator can over-allocate beyond the committed seqlen, and those
@@ -1229,40 +1224,169 @@ class HiSparseCoordinator:
         # subsequent release_kv_cache -> allocator.free -> free_hisparse path
         # re-frees them (double-free into the page allocator's free list).
         allocated_len = req.kv_allocated_len
+        host_len = self.host_token_len(allocated_len)
 
         # release memory -- only free actually-allocated buffer indices
-        current_cap = int(self.req_device_buffer_size[req.req_pool_idx])
+        current_cap = int(self.req_device_buffer_size[req_idx])
         if current_cap > 0:
-            side_buf_hi = self.req_to_device_buffer[req.req_pool_idx, :current_cap]
+            side_buf_hi = self.req_to_device_buffer[req_idx, :current_cap]
             all_hi = torch.unique(side_buf_hi[side_buf_hi > 0])
             if all_hi.numel() > 0:
                 self.token_to_kv_pool_allocator.free_hisparse_indices(all_hi)
 
-        allocated_locs = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, :allocated_len
-        ]
+        allocated_locs = self.req_to_token_pool.req_to_token[req_idx, :allocated_len]
         compressed_locs = self.mem_pool_device.translate_loc_from_full_to_compressed(
             allocated_locs
         )
         self.mem_pool_device.full_to_hisparse_device_index_mapping[compressed_locs] = 0
 
-        host_indices = self.mem_pool_host.allocated_host_indices(
-            self.req_to_host_pool,
-            req.req_pool_idx,
-            self.req_to_host_pool_allocated_len[req.req_pool_idx],
-        )
+        # clear req info
+        self.req_device_buffer_tokens[:, req_idx, :] = -1
+        self.req_device_buffer_token_locs[:, req_idx, :] = -1
+        self.req_to_device_buffer[req_idx, :] = 0
+        self.req_device_buffer_size[req_idx] = 0
+        self.lru_slots[:, req_idx, :].copy_(self._lru_init)
+        self._skip_first_backup[req_idx] = False
+        return host_len
+
+    def _free_host_indices(self, host_indices: torch.Tensor) -> None:
+        host_indices = host_indices[host_indices >= 0]
         if host_indices.numel() > 0:
             self.mem_pool_host.free(host_indices)
 
-        # clear req info
-        self.req_device_buffer_tokens[:, req.req_pool_idx, :] = -1
-        self.req_device_buffer_token_locs[:, req.req_pool_idx, :] = -1
-        self.req_to_device_buffer[req.req_pool_idx, :] = 0
-        self.req_device_buffer_size[req.req_pool_idx] = 0
-        self.req_to_host_pool[req.req_pool_idx, :] = -1
-        self.req_to_host_pool_allocated_len[req.req_pool_idx] = 0
-        self.lru_slots[:, req.req_pool_idx, :].copy_(self._lru_init)
-        self._skip_first_backup[req.req_pool_idx] = False
+    @staticmethod
+    def _req_pool_idx(req: Req) -> int:
+        req_idx = req.req_pool_idx
+        if isinstance(req_idx, torch.Tensor):
+            if req_idx.numel() != 1:
+                raise ValueError(
+                    f"HiSparse req {req.rid} has non-scalar req_pool_idx: "
+                    f"shape={tuple(req_idx.shape)} value={req_idx}"
+                )
+            req_idx = int(req_idx.item())
+            req.req_pool_idx = req_idx
+        return req_idx
+
+    def _clear_retracted_host_indices(self, req: Req) -> None:
+        if hasattr(req, "hisparse_retracted_host_indices"):
+            del req.hisparse_retracted_host_indices
+        if hasattr(req, "hisparse_retracted_host_len"):
+            del req.hisparse_retracted_host_len
+
+    def release_retracted_req(self, req: Req) -> None:
+        host_indices = getattr(req, "hisparse_retracted_host_indices", None)
+        if host_indices is not None:
+            self._free_host_indices(host_indices)
+        self._clear_retracted_host_indices(req)
+
+    def pop_retracted_host_indices(
+        self, req: Req, host_len: int
+    ) -> Union[torch.Tensor, None]:
+        host_indices = getattr(req, "hisparse_retracted_host_indices", None)
+        if host_indices is None:
+            return None
+        if host_indices.numel() < host_len:
+            raise RuntimeError(
+                f"HiSparse retracted host indices too short for req {req.rid}: "
+                f"{host_indices.numel()} < {host_len}"
+            )
+
+        restored_indices = host_indices[:host_len].to(device=self.device)
+        self._free_host_indices(host_indices[host_len:])
+        self._clear_retracted_host_indices(req)
+        return restored_indices
+
+    def _ensure_host_backed(self, req: Req, preserve_len: int, host_len: int) -> bool:
+        host_indices = self.req_to_host_pool[req.req_pool_idx, :host_len]
+        missing_positions = torch.nonzero(host_indices < 0, as_tuple=False).flatten()
+        if missing_positions.numel() == 0:
+            return True
+
+        if self.compress_ratio == 1:
+            full_positions = missing_positions
+        else:
+            full_positions = missing_positions * self.compress_ratio + (
+                self.compress_ratio - 1
+            )
+            if torch.any(full_positions >= preserve_len):
+                logger.warning(
+                    "HiSparse cannot retract req %s: compressed host positions map "
+                    "past preserve_len (%s >= %s)",
+                    req.rid,
+                    full_positions.tolist(),
+                    preserve_len,
+                )
+                return False
+
+        logical_locs = self.req_to_token_pool.req_to_token[
+            req.req_pool_idx, full_positions
+        ]
+        compressed_locs = self.mem_pool_device.translate_loc_from_full_to_compressed(
+            logical_locs
+        )
+        device_locs = self.mem_pool_device.full_to_hisparse_device_index_mapping[
+            compressed_locs
+        ]
+        if torch.any(device_locs <= 0):
+            bad_positions = missing_positions[device_locs <= 0].tolist()
+            logger.warning(
+                "HiSparse cannot retract req %s: host backup is missing and no "
+                "live device mapping exists for positions %s",
+                req.rid,
+                bad_positions,
+            )
+            return False
+
+        new_host_indices = self.mem_pool_host.alloc(missing_positions.numel())
+        if new_host_indices is None:
+            logger.warning(
+                "HiSparse cannot retract req %s: host mem pool alloc failed for "
+                "%d backup tokens, available=%d",
+                req.rid,
+                missing_positions.numel(),
+                self.mem_pool_host.available_size(),
+            )
+            return False
+        new_host_indices = new_host_indices.to(device=self.device)
+        self._backup_device_locs_to_host(new_host_indices, device_locs)
+        self.req_to_host_pool[req.req_pool_idx, missing_positions] = new_host_indices
+        return True
+
+    def retract_req(self, req: Req) -> bool:
+        if req.hisparse_staging:
+            self.abort_staging_request(req)
+            return True
+
+        preserve_len = len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
+        req_idx = self._req_pool_idx(req)
+        host_len = self.host_token_len(preserve_len)
+        stale_host_indices = self.req_to_host_pool[req_idx, host_len:]
+        self._free_host_indices(stale_host_indices)
+        self.req_to_host_pool[req_idx, host_len:] = -1
+        if not self._ensure_host_backed(req, preserve_len, host_len):
+            return False
+        req.hisparse_retracted_host_indices = self.req_to_host_pool[
+            req_idx, :host_len
+        ].clone()
+        req.hisparse_retracted_host_len = host_len
+        self._clear_req_device_state(req)
+        self.req_to_host_pool[req_idx, :] = -1
+        self.req_to_host_pool_allocated_len[req_idx] = 0
+        return True
+
+    def request_finished(self, req: Req):
+        req_idx = self._req_pool_idx(req)
+        self._clear_req_device_state(req)
+
+        host_indices = self.mem_pool_host.allocated_host_indices(
+            self.req_to_host_pool,
+            req_idx,
+            self.req_to_host_pool_allocated_len[req_idx],
+        )
+        self._free_host_indices(host_indices)
+        self.req_to_host_pool[req_idx, :] = -1
+        self.req_to_host_pool_allocated_len[req_idx] = 0
+        self._clear_retracted_host_indices(req)
 
     def swap_in_selected_pages(
         self,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2042,6 +2042,9 @@ class DisaggregationMetrics:
     """PD disaggregation metrics."""
 
     mode: str  # "prefill", "decode", or "null" - not a metric
+    prefill_pending_queue_reqs: int = field(
+        default=0, metadata={"metric": ("gauge", "Prefill pending queue requests")}
+    )
     prefill_bootstrap_queue_reqs: int = field(
         default=0, metadata={"metric": ("gauge", "Prefill bootstrap queue requests")}
     )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1015,6 +1015,7 @@ class Req(ReqDllmMixin):
 
         # For hisparse
         self.hisparse_staging = False
+        self.hisparse_spec_info = None
 
     @property
     def seqlen(self) -> int:
@@ -1462,6 +1463,7 @@ class Req(ReqDllmMixin):
         self.kv_committed_len = 0
         self.kv_committed_freed = False
         self.kv_overallocated_freed = False
+        self.hisparse_spec_info = None
         self.swa_evicted_seqlen = 0
         self.extend_batch_idx = 0
         self.decode_batch_idx = 0
@@ -2801,6 +2803,90 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         if self.spec_info:
             self.spec_info.merge_batch(other.spec_info)
 
+    def get_model_worker_batch(
+        self, seq_lens_cpu_cache: Optional[torch.Tensor] = None
+    ) -> ModelWorkerBatch:
+        if self.forward_mode.is_decode_or_idle():
+            extend_seq_lens = extend_prefix_lens = extend_logprob_start_lens = None
+        else:
+            extend_seq_lens = self.extend_lens
+            extend_prefix_lens = self.prefix_lens
+            extend_logprob_start_lens = self.extend_logprob_start_lens
+
+        if self.sampling_info:
+            if self.has_grammar:
+                self.sampling_info.grammars = [req.grammar for req in self.reqs]
+            else:
+                self.sampling_info.grammars = None
+
+        seq_lens_cpu = (
+            seq_lens_cpu_cache if seq_lens_cpu_cache is not None else self.seq_lens_cpu
+        )
+
+        return ModelWorkerBatch(
+            forward_mode=self.forward_mode,
+            input_ids=self.input_ids,
+            req_pool_indices=self.req_pool_indices,
+            seq_lens=self.seq_lens,
+            orig_seq_lens=self.orig_seq_lens,
+            out_cache_loc=self.out_cache_loc,
+            seq_lens_cpu=seq_lens_cpu,
+            seq_lens_sum=self.seq_lens_sum,
+            return_logprob=self.return_logprob,
+            top_logprobs_nums=self.top_logprobs_nums,
+            token_ids_logprobs=self.token_ids_logprobs,
+            global_num_tokens=self.global_num_tokens,
+            global_num_tokens_for_logprob=self.global_num_tokens_for_logprob,
+            is_extend_in_batch=self.is_extend_in_batch,
+            all_extend_in_batch=self.all_extend_in_batch,
+            can_run_dp_cuda_graph=self.can_run_dp_cuda_graph,
+            tbo_split_seq_index=self.tbo_split_seq_index,
+            global_forward_mode=self.global_forward_mode,
+            extend_num_tokens=self.extend_num_tokens,
+            extend_seq_lens=extend_seq_lens,
+            extend_prefix_lens=extend_prefix_lens,
+            extend_logprob_start_lens=extend_logprob_start_lens,
+            multimodal_inputs=self.multimodal_inputs,
+            encoder_cached=self.encoder_cached,
+            encoder_lens=self.encoder_lens,
+            encoder_lens_cpu=self.encoder_lens_cpu,
+            encoder_out_cache_loc=self.encoder_out_cache_loc,
+            lora_ids=[req.lora_id for req in self.reqs],
+            sampling_info=self.sampling_info,
+            input_embeds=self.input_embeds,
+            replace_embeds=self.replace_embeds,
+            replace_positions=self.replace_positions,
+            ne_token_table=self.ne_token_table,
+            token_type_ids=self.token_type_ids,
+            spec_algorithm=self.spec_algorithm,
+            spec_info=self.spec_info,
+            hicache_consumer_index=self.hicache_consumer_index,
+            capture_hidden_mode=(
+                CaptureHiddenMode.FULL
+                if self.return_hidden_states
+                else (
+                    getattr(
+                        self.spec_info, "capture_hidden_mode", CaptureHiddenMode.NULL
+                    )
+                    if self.spec_info
+                    else CaptureHiddenMode.NULL
+                )
+            ),
+            extend_input_logprob_token_ids=self.extend_input_logprob_token_ids,
+            is_prefill_only=self.is_prefill_only,
+            multi_item_delimiter_indices=self.multi_item_delimiter_indices,
+            dimensions=self.dimensions,
+            return_pooled_hidden_states=self.return_pooled_hidden_states,
+            dllm_block_offsets=[req.dllm_block_offset for req in self.reqs],
+            dllm_config=self.dllm_config,
+            reqs=self.reqs,
+            has_grammar=self.has_grammar,
+            mamba_track_indices=self.mamba_track_indices,
+            mamba_track_mask=self.mamba_track_mask,
+            mamba_track_seqlens=self.mamba_track_seqlens,
+            hisparse_coordinator=self.hisparse_coordinator,
+        )
+
     def copy(self):
         # Only contain fields that will be used by process_batch_result.
         # Shallow-copy the reqs list so that in-place mutations (filter_batch,
@@ -2909,3 +2995,111 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             f"ScheduleBatch(forward_mode={self.forward_mode.name if self.forward_mode else 'None'}, "
             f"#req={(len(self.reqs))})"
         )
+
+
+@dataclasses.dataclass
+class ModelWorkerBatch:
+    # The forward mode
+    forward_mode: ForwardMode
+    # The input ids
+    input_ids: torch.Tensor
+    # The indices of requests in the req_to_token_pool
+    req_pool_indices: torch.Tensor
+    # The sequence length
+    seq_lens: torch.Tensor
+    # The indices of output tokens in the token_to_kv_pool_allocator
+    out_cache_loc: torch.Tensor
+    # The sequence length tensor on CPU
+    seq_lens_cpu: Optional[torch.Tensor]
+    seq_lens_sum: int
+
+    # For logprob
+    return_logprob: bool
+    top_logprobs_nums: Optional[List[int]]
+    token_ids_logprobs: Optional[List[List[int]]]
+
+    # For DP attention
+    global_num_tokens: Optional[List[int]]
+    global_num_tokens_for_logprob: Optional[List[int]]
+    is_extend_in_batch: bool
+    all_extend_in_batch: bool
+    can_run_dp_cuda_graph: bool
+    tbo_split_seq_index: Optional[int]
+    global_forward_mode: Optional[ForwardMode]
+
+    # For extend
+    extend_num_tokens: Optional[int]
+    extend_seq_lens: Optional[List[int]]
+    extend_prefix_lens: Optional[List[int]]
+    extend_logprob_start_lens: Optional[List[int]]
+    extend_input_logprob_token_ids: Optional[torch.Tensor]
+
+    # For multimodal
+    multimodal_inputs: Optional[List[MultimodalInputs]]
+
+    # For encoder-decoder
+    encoder_cached: Optional[List[bool]]
+    encoder_lens: Optional[torch.Tensor]
+    encoder_lens_cpu: Optional[List[int]]
+    encoder_out_cache_loc: Optional[torch.Tensor]
+
+    # For LoRA
+    lora_ids: Optional[List[str]]
+
+    # Sampling info
+    sampling_info: SamplingBatchInfo
+
+    # The original sequence lengths, Qwen-1M related
+    orig_seq_lens: Optional[torch.Tensor] = None
+
+    # The input Embeds
+    input_embeds: Optional[torch.Tensor] = None
+    replace_embeds: Optional[torch.Tensor] = None
+    replace_positions: Optional[torch.Tensor] = None
+
+    # token table for ngram embedding
+    ne_token_table: Optional[torch.Tensor] = None
+
+    # For corss-encoder model
+    token_type_ids: Optional[torch.Tensor] = None
+
+    # Speculative decoding
+    spec_algorithm: SpeculativeAlgorithm = None
+
+    spec_info: Optional[SpecInput] = None
+
+    # If set, the output of the batch contains the hidden states of the run.
+    capture_hidden_mode: CaptureHiddenMode = None
+    hicache_consumer_index: int = -1
+
+    # For matryoshka embeddings
+    dimensions: Optional[list[int]] = None
+
+    # Whether to return pooled hidden states (pre-head transformer output)
+    return_pooled_hidden_states: bool = False
+
+    # Whether this batch is prefill-only (no token generation needed)
+    is_prefill_only: bool = False
+
+    # Pre-computed delimiter indices for multi-item scoring (CPU tensors, one per request)
+    multi_item_delimiter_indices: Optional[List[torch.Tensor]] = None
+
+    # Diffusion LLM
+    dllm_block_offsets: Optional[List[int]] = None
+    dllm_config: Optional[DllmConfig] = None
+
+    # For constrained decoding
+    # FIXME(lsyin): remove this after fully overlap grammar
+    reqs: Optional[List[Req]] = None
+    has_grammar: bool = False
+
+    # For hidden states before normal
+    return_hidden_states_before_norm: bool = False
+
+    # For mamba state tracking
+    mamba_track_indices: Optional[torch.Tensor] = None  # shape: [b], int64
+    mamba_track_mask: Optional[torch.Tensor] = None  # shape: [b], bool
+    mamba_track_seqlens: Optional[torch.Tensor] = None  # shape: [b], int64
+
+    # HiSparse
+    hisparse_coordinator: Optional[HiSparseCoordinator] = None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2443,17 +2443,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         ):
             return 0
 
-        if self.is_spec_v2:
-            max_accepted_tokens = get_alloc_len_per_decode() + 1
-        else:
-            server_args = get_global_server_args()
-            max_accepted_tokens = (
-                max(
-                    server_args.speculative_num_steps or 0,
-                    server_args.speculative_num_draft_tokens or 0,
-                )
-                + 1
-            )
+        max_accepted_tokens = get_alloc_len_per_decode() + 1
         return max_accepted_tokens * len(requests)
 
     def _new_tokens_required_next_decode_spec_v2(self, requests, page_size):

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2434,6 +2434,29 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
         return self._new_tokens_required_next_decode_spec_v2(requests, page_size)
 
+    def _host_tokens_required_next_decode_spec(self, requests: List[Req]) -> int:
+        if (
+            self.hisparse_coordinator is None
+            or self.spec_algorithm.is_none()
+            or not self.hisparse_coordinator.supports_hisparse_draft_slots()
+        ):
+            return 0
+
+        server_args = get_global_server_args()
+        if self.is_spec_v2:
+            from sglang.srt.managers.utils import get_alloc_len_per_decode
+
+            max_accepted_tokens = get_alloc_len_per_decode() + 1
+        else:
+            max_accepted_tokens = (
+                max(
+                    server_args.speculative_num_steps or 0,
+                    server_args.speculative_num_draft_tokens or 0,
+                )
+                + 1
+            )
+        return max_accepted_tokens * len(requests)
+
     def _new_tokens_required_next_decode_spec_v2(self, requests, page_size):
         """Tight estimate matching eagle_info_v2.prepare_for_decode allocation."""
         reserve = get_alloc_reserve_per_decode()
@@ -2448,7 +2471,24 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     def check_decode_mem(self, selected_indices: Optional[List[int]] = None):
         num_tokens = self.new_tokens_required_next_decode(selected_indices)
         evict_from_tree_cache(self.tree_cache, num_tokens)
-        return self.token_to_kv_pool_allocator.available_size() >= num_tokens
+        if self.token_to_kv_pool_allocator.available_size() < num_tokens:
+            return False
+
+        if self.hisparse_coordinator is None:
+            return True
+
+        requests = (
+            self.reqs
+            if selected_indices is None
+            else [self.reqs[i] for i in selected_indices]
+        )
+        host_required = self.hisparse_coordinator.host_tokens_required_next_decode(
+            requests,
+            speculative_token_budget=self._host_tokens_required_next_decode_spec(
+                requests
+            ),
+        )
+        return self.hisparse_coordinator.mem_pool_host.available_size() >= host_required
 
     def retract_all(self, server_args: ServerArgs):
         retracted_reqs = retract_all(

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1607,11 +1607,24 @@ def release_req(
     token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
     tree_cache: BasePrefixCache,
     hisparse_coordinator: Optional[HiSparseCoordinator],
-) -> None:
-    if hisparse_coordinator is not None and not req.finished():
-        hisparse_coordinator.retract_req(req)
+) -> bool:
+    should_retract = not isinstance(getattr(req, "to_finish", None), FINISH_ABORT)
 
-    if server_args.disaggregation_mode == "decode":
+    if hisparse_coordinator is not None and not req.finished():
+        if not should_retract:
+            hisparse_coordinator.request_finished(req)
+        else:
+            should_retract = hisparse_coordinator.retract_req(req)
+            if not should_retract:
+                req.to_finish = FINISH_ABORT(
+                    "HiSparse preallocated host KV pool had no free slots while "
+                    "backing up the request for retract. Aborting this request "
+                    "instead of crashing the scheduler.",
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                )
+                hisparse_coordinator.request_finished(req)
+
+    if server_args.disaggregation_mode == "decode" and hisparse_coordinator is None:
         req.offload_kv_cache(req_to_token_pool, token_to_kv_pool_allocator)
     # TODO (csy): for preempted requests, we may want to insert into the tree
     release_kv_cache(req, tree_cache, is_insert=False)
@@ -1619,7 +1632,9 @@ def release_req(
     num_tokens = remaing_req_count * envs.SGLANG_RETRACT_DECODE_STEPS.get()
     evict_from_tree_cache(tree_cache, num_tokens)
 
-    req.reset_for_retract()
+    if should_retract:
+        req.reset_for_retract()
+    return should_retract
 
 
 def retract_all(
@@ -2468,6 +2483,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             )
 
         retracted_reqs = []
+        reqs_to_abort: List[Req] = []
         first_iter = True
         while first_iter or (
             not self.check_decode_mem(selected_indices=sorted_indices)
@@ -2479,11 +2495,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             first_iter = False
             idx = sorted_indices.pop()
             req = self.reqs[idx]
-            retracted_reqs.append(req)
             # release memory and don't insert into the tree because we need the space instantly
-            self.release_req(idx, len(sorted_indices), server_args)
+            if self.release_req(idx, len(sorted_indices), server_args):
+                retracted_reqs.append(req)
+            else:
+                reqs_to_abort.append(req)
 
-        reqs_to_abort: List[Req] = []
         if len(sorted_indices) <= 1 and not self.check_decode_mem(
             selected_indices=sorted_indices
         ):
@@ -2511,8 +2528,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
         return retracted_reqs, new_estimate_ratio, reqs_to_abort
 
-    def release_req(self, idx: int, remaing_req_count: int, server_args: ServerArgs):
-        release_req(
+    def release_req(
+        self, idx: int, remaing_req_count: int, server_args: ServerArgs
+    ) -> bool:
+        return release_req(
             req=self.reqs[idx],
             remaing_req_count=remaing_req_count,
             server_args=server_args,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -84,6 +84,7 @@ from sglang.srt.mem_cache.common import (
     alloc_for_extend,
     evict_from_tree_cache,
     free_swa_out_of_window_slots,
+    get_alloc_len_per_decode,
     get_alloc_reserve_per_decode,
     release_kv_cache,
 )
@@ -2442,12 +2443,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         ):
             return 0
 
-        server_args = get_global_server_args()
         if self.is_spec_v2:
-            from sglang.srt.managers.utils import get_alloc_len_per_decode
-
             max_accepted_tokens = get_alloc_len_per_decode() + 1
         else:
+            server_args = get_global_server_args()
             max_accepted_tokens = (
                 max(
                     server_args.speculative_num_steps or 0,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3880,8 +3880,11 @@ class Scheduler(
                 remaining_retracted = []
                 for decode_req in self.disagg_decode_prealloc_queue.retracted_queue:
                     if recv_req.abort_all or decode_req.rid.startswith(recv_req.rid):
-                        assert hasattr(decode_req, "kv_cache_cpu")
-                        del decode_req.kv_cache_cpu
+                        if self.enable_hisparse:
+                            self.hisparse_coordinator.release_retracted_req(decode_req)
+                        else:
+                            assert hasattr(decode_req, "kv_cache_cpu")
+                            del decode_req.kv_cache_cpu
                         self.ipc_channels.send_to_tokenizer.send_output(
                             AbortReq(rid=decode_req.rid), decode_req
                         )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2482,7 +2482,7 @@ class Scheduler(
                 batch.spec_info.merge_batch(req.hisparse_spec_info)
                 req.hisparse_spec_info = None
 
-            if batch.is_spec_v2:
+            if not batch.spec_algorithm.is_none():
                 if batch.spec_info.new_seq_lens is None:
                     raise RuntimeError(
                         "HiSparse spec-v2 decode batch is missing new_seq_lens for draft state rebuild."
@@ -3225,7 +3225,7 @@ class Scheduler(
                 self.update_cache_from_scheduler(batch, batch_result)
                 if (
                     self.enable_hisparse
-                    and batch.is_spec_v2
+                    and not batch.spec_algorithm.is_none()
                     and batch_result.next_draft_input is not None
                 ):
                     batch.spec_info = batch_result.next_draft_input

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3783,7 +3783,9 @@ class Scheduler(
                     logger.debug(f"Abort pending bootstrap request. {req.rid=}")
                     if self.enable_hicache_storage:
                         self.tree_cache.release_aborted_request(req.rid)
-                    self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+                    self.ipc_channels.send_to_tokenizer.send_output(
+                        AbortReq(rid=req.rid), req
+                    )
                 else:
                     remaining_pending.append(req)
             self.disagg_prefill_bootstrap_queue.pending_queue = remaining_pending
@@ -3799,7 +3801,9 @@ class Scheduler(
                         req.disagg_kv_sender.clear()
                     if self.enable_hicache_storage:
                         self.tree_cache.release_aborted_request(req.rid)
-                    self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+                    self.ipc_channels.send_to_tokenizer.send_output(
+                        AbortReq(rid=req.rid), req
+                    )
                 else:
                     remaining_bootstrap.append(req)
             self.disagg_prefill_bootstrap_queue.queue = remaining_bootstrap
@@ -3817,7 +3821,9 @@ class Scheduler(
                     release_req_to_metadata_buffer(
                         req, self.req_to_metadata_buffer_idx_allocator
                     )
-                    self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+                    self.ipc_channels.send_to_tokenizer.send_output(
+                        AbortReq(rid=req.rid), req
+                    )
                 else:
                     remaining_inflight.append(req)
             self.disagg_prefill_inflight_queue = remaining_inflight
@@ -3833,7 +3839,7 @@ class Scheduler(
                     if hasattr(decode_req.kv_receiver, "clear"):
                         decode_req.kv_receiver.clear()
                     aborted_prealloc_rids.add(decode_req.req.rid)
-                    self.send_to_tokenizer.send_output(
+                    self.ipc_channels.send_to_tokenizer.send_output(
                         AbortReq(rid=decode_req.req.rid), decode_req.req
                     )
                 else:
@@ -3873,7 +3879,7 @@ class Scheduler(
                     if self.enable_hisparse:
                         self.hisparse_coordinator.request_finished(decode_req.req)
                     release_kv_cache(decode_req.req, self.tree_cache, is_insert=False)
-                    self.send_to_tokenizer.send_output(
+                    self.ipc_channels.send_to_tokenizer.send_output(
                         AbortReq(rid=decode_req.req.rid), decode_req.req
                     )
                 else:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2335,6 +2335,10 @@ class Scheduler(
                     ),
                     req,
                 )
+                if self.disaggregation_mode == DisaggregationMode.DECODE:
+                    if self.enable_hisparse:
+                        self.hisparse_coordinator.request_finished(req)
+                    release_kv_cache(req, self.tree_cache, is_insert=False)
                 deleted_reqs.add(req)
 
         if deleted_reqs:
@@ -3721,7 +3725,6 @@ class Scheduler(
         return RpcReqOutput(success, "" if not exec else str(exec))
 
     def abort_request(self, recv_req: AbortReq):
-        # todo hisparse, release resources for abort requests in hisparse coordinator
         # Delete requests in the waiting queue
         to_del = []
         for i, req in enumerate(self.waiting_queue):
@@ -3740,6 +3743,8 @@ class Scheduler(
             self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
             # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
             if self.disaggregation_mode == DisaggregationMode.DECODE:
+                if self.enable_hisparse:
+                    self.hisparse_coordinator.request_finished(req)
                 release_kv_cache(req, self.tree_cache)
             # For disaggregation prefill mode, free the metadata buffer index
             if self.disaggregation_mode == DisaggregationMode.PREFILL:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2459,7 +2459,40 @@ class Scheduler(
         batch.sampling_info = SamplingBatchInfo.from_schedule_batch(
             batch, self.model_config.vocab_size
         )
-        # todo hisparse, maybe other info to contain for the new batch
+
+        if not batch.spec_algorithm.is_none():
+            missing_spec_info_rids = [
+                req.rid
+                for req in reqs
+                if getattr(req, "hisparse_spec_info", None) is None
+            ]
+            if missing_spec_info_rids:
+                raise RuntimeError(
+                    "HiSparse decode batch is missing speculative draft state for requests: "
+                    + ", ".join(missing_spec_info_rids)
+                )
+
+            batch.spec_info = reqs[0].hisparse_spec_info
+            reqs[0].hisparse_spec_info = None
+            for req in reqs[1:]:
+                batch.spec_info.merge_batch(req.hisparse_spec_info)
+                req.hisparse_spec_info = None
+
+            if batch.is_spec_v2:
+                if batch.spec_info.new_seq_lens is None:
+                    raise RuntimeError(
+                        "HiSparse spec-v2 decode batch is missing new_seq_lens for draft state rebuild."
+                    )
+                future_indices = self.future_map.alloc_future_indices(len(reqs))
+                self.future_map.store_to_map_for_new_batch(
+                    future_indices, batch.spec_info
+                )
+                batch.spec_info.future_indices = future_indices
+                batch.spec_info.verify_done = None
+                batch.seq_lens = batch.spec_info.new_seq_lens
+                batch.seq_lens_cpu = batch.seq_lens.cpu()
+                batch.orig_seq_lens = batch.seq_lens.to(dtype=torch.int32)
+                batch.seq_lens_sum = batch.seq_lens_cpu.sum().item()
         return batch
 
     @scheduler_nvtx_method("scheduler.get_next_batch_to_run")
@@ -3186,6 +3219,12 @@ class Scheduler(
                     )
                     batch.input_ids = None
                 self.update_cache_from_scheduler(batch, batch_result)
+                if (
+                    self.enable_hisparse
+                    and batch.is_spec_v2
+                    and batch_result.next_draft_input is not None
+                ):
+                    batch.spec_info = batch_result.next_draft_input
 
             # These 2 values are needed for processing the output, but the values can be
             # modified by overlap schedule. So we have to copy them here so that
@@ -3418,6 +3457,7 @@ class Scheduler(
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 idle &= len(self.disagg_prefill_inflight_queue) == 0
                 idle &= len(self.disagg_prefill_bootstrap_queue.queue) == 0
+                idle &= len(self.disagg_prefill_bootstrap_queue.pending_queue) == 0
 
             if self.disaggregation_mode == DisaggregationMode.DECODE:
                 idle &= len(self.disagg_decode_prealloc_queue.queue) == 0
@@ -3731,32 +3771,109 @@ class Scheduler(
 
         # Delete requests not in the waiting queue when PD disaggregation is enabled
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            # Abort requests that are queued before KV sender admission.
+            remaining_pending = deque()
+            for req in self.disagg_prefill_bootstrap_queue.pending_queue:
+                if recv_req.abort_all or req.rid.startswith(recv_req.rid):
+                    logger.debug(f"Abort pending bootstrap request. {req.rid=}")
+                    if self.enable_hicache_storage:
+                        self.tree_cache.release_aborted_request(req.rid)
+                    self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+                else:
+                    remaining_pending.append(req)
+            self.disagg_prefill_bootstrap_queue.pending_queue = remaining_pending
+
             # Abort requests that have not yet been bootstrapped
+            remaining_bootstrap = []
             for req in self.disagg_prefill_bootstrap_queue.queue:
                 if recv_req.abort_all or req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort bootstrap queue request. {req.rid=}")
                     if hasattr(req.disagg_kv_sender, "abort"):
                         req.disagg_kv_sender.abort()
+                    if hasattr(req.disagg_kv_sender, "clear"):
+                        req.disagg_kv_sender.clear()
+                    if self.enable_hicache_storage:
+                        self.tree_cache.release_aborted_request(req.rid)
+                    self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+                else:
+                    remaining_bootstrap.append(req)
+            self.disagg_prefill_bootstrap_queue.queue = remaining_bootstrap
 
             # Abort in-flight requests
+            remaining_inflight = []
             for req in self.disagg_prefill_inflight_queue:
                 if recv_req.abort_all or req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort inflight queue request. {req.rid=}")
                     if hasattr(req.disagg_kv_sender, "abort"):
                         req.disagg_kv_sender.abort()
+                    if hasattr(req.disagg_kv_sender, "clear"):
+                        req.disagg_kv_sender.clear()
+                    release_kv_cache(req, self.tree_cache, is_insert=False)
+                    release_req_to_metadata_buffer(
+                        req, self.req_to_metadata_buffer_idx_allocator
+                    )
+                    self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+                else:
+                    remaining_inflight.append(req)
+            self.disagg_prefill_inflight_queue = remaining_inflight
 
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
             # Abort requests that have not yet finished preallocation
+            aborted_prealloc_rids = set()
+            remaining_prealloc = []
             for decode_req in self.disagg_decode_prealloc_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort prealloc queue request. {decode_req.req.rid=}")
                     decode_req.kv_receiver.abort()
+                    if hasattr(decode_req.kv_receiver, "clear"):
+                        decode_req.kv_receiver.clear()
+                    aborted_prealloc_rids.add(decode_req.req.rid)
+                    self.send_to_tokenizer.send_output(
+                        AbortReq(rid=decode_req.req.rid), decode_req.req
+                    )
+                else:
+                    remaining_prealloc.append(decode_req)
+            self.disagg_decode_prealloc_queue.queue = remaining_prealloc
+            if aborted_prealloc_rids:
+                self.disagg_decode_prealloc_queue.pending_reqs = [
+                    decode_req
+                    for decode_req in self.disagg_decode_prealloc_queue.pending_reqs
+                    if decode_req.req.rid not in aborted_prealloc_rids
+                ]
 
             # Abort requests waiting for kvcache to release tree cache
+            transfer_queue = self.disagg_decode_transfer_queue
+            remaining_transfer = []
             for decode_req in self.disagg_decode_transfer_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
                     decode_req.kv_receiver.abort()
+                    if (
+                        transfer_queue.enable_staging
+                        and transfer_queue.staging_handler is not None
+                        and transfer_queue.staging_handler.is_staging_room(
+                            decode_req.req.bootstrap_room
+                        )
+                    ):
+                        transfer_queue.staging_handler.unregister_decode_req(
+                            decode_req.req.bootstrap_room
+                        )
+                    if decode_req.metadata_buffer_index != -1:
+                        transfer_queue.req_to_metadata_buffer_idx_allocator.free(
+                            decode_req.metadata_buffer_index
+                        )
+                        decode_req.metadata_buffer_index = -1
+                    if hasattr(decode_req.kv_receiver, "clear"):
+                        decode_req.kv_receiver.clear()
+                    if self.enable_hisparse:
+                        self.hisparse_coordinator.request_finished(decode_req.req)
+                    release_kv_cache(decode_req.req, self.tree_cache, is_insert=False)
+                    self.send_to_tokenizer.send_output(
+                        AbortReq(rid=decode_req.req.rid), decode_req.req
+                    )
+                else:
+                    remaining_transfer.append(decode_req)
+            self.disagg_decode_transfer_queue.queue = remaining_transfer
 
             # Abort requests already retracted to CPU cache
             if self.disagg_decode_prealloc_queue.retracted_queue:

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -833,6 +833,14 @@ class SchedulerBatchResultProcessor:
                 # Asynchronously offload KV cache; release_kv_cache will be called after Device->Host transfer completes
                 if not self.decode_offload_manager.offload_kv_cache(req):
                     self.decode_offload_manager.finalize_release_on_finish(req)
+            elif req.req_pool_idx is None:
+                logger.warning(
+                    "Skip KV release for finished req %s because req_pool_idx is "
+                    "already None (kv_committed_freed=%s, kv_overallocated_freed=%s)",
+                    req.rid,
+                    req.kv_committed_freed,
+                    req.kv_overallocated_freed,
+                )
             else:
                 if self.server_args.enable_hisparse:
                     self.hisparse_coordinator.request_finished(req)

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -175,6 +175,17 @@ class SchedulerBatchResultProcessor:
                     elem = elem.copy()
                 req.customized_info[k].append(elem)
 
+    def _stash_hisparse_spec_info(
+        self, batch: ScheduleBatch, batch_index: int, req: Req
+    ) -> None:
+        if not self.server_args.enable_hisparse or batch.spec_info is None:
+            return
+        if not hasattr(batch.spec_info, "slice_single"):
+            raise RuntimeError(
+                f"HiSparse cannot stash speculative state for {type(batch.spec_info).__name__}"
+            )
+        req.hisparse_spec_info = batch.spec_info.slice_single(batch_index)
+
     def process_batch_result_prefill(
         self,
         batch: ScheduleBatch,
@@ -203,6 +214,12 @@ class SchedulerBatchResultProcessor:
                 result.extend_input_len_per_req,
                 result.extend_logprob_start_len_per_req,
             )
+            if (
+                self.server_args.enable_hisparse
+                and batch.spec_info is None
+                and result.next_draft_input is not None
+            ):
+                batch.spec_info = result.next_draft_input
 
             # Move next_token_ids and logprobs to cpu
             next_token_ids = next_token_ids.tolist()
@@ -237,6 +254,7 @@ class SchedulerBatchResultProcessor:
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                         maybe_cache_unfinished_req(req, self.tree_cache)
                         if self.server_args.enable_hisparse:
+                            self._stash_hisparse_spec_info(batch, i, req)
                             self.hisparse_coordinator.admit_request_into_staging(req)
 
                     self._maybe_collect_customized_info(i, req, logits_output)

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -834,6 +834,8 @@ class SchedulerBatchResultProcessor:
                 if not self.decode_offload_manager.offload_kv_cache(req):
                     self.decode_offload_manager.finalize_release_on_finish(req)
             elif req.req_pool_idx is None:
+                if getattr(req, "mamba_pool_idx", None) is not None:
+                    release_kv_cache(req, self.tree_cache)
                 logger.warning(
                     "Skip KV release for finished req %s because req_pool_idx is "
                     "already None (kv_committed_freed=%s, kv_overallocated_freed=%s)",

--- a/python/sglang/srt/managers/scheduler_components/load_inquirer.py
+++ b/python/sglang/srt/managers/scheduler_components/load_inquirer.py
@@ -106,8 +106,13 @@ class SchedulerLoadInquirer:
         waiting_queues = [self.get_waiting_queue()]
         pending_token_queues = [self.get_waiting_queue()]
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            prefill_pending_queue = (
+                self.get_disagg_prefill_bootstrap_queue().pending_queue
+            )
             prefill_bootstrap_queue = self.get_disagg_prefill_bootstrap_queue().queue
+            waiting_queues.append(prefill_pending_queue)
             waiting_queues.append(prefill_bootstrap_queue)
+            pending_token_queues.append(prefill_pending_queue)
             pending_token_queues.append(prefill_bootstrap_queue)
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
             decode_prealloc_queue = self.get_disagg_decode_prealloc_queue().queue
@@ -174,6 +179,7 @@ class SchedulerLoadInquirer:
         disaggregation = None
         if include_all or "disagg" in include:
             mode_str = "null"
+            prefill_pending = 0
             prefill_bootstrap = 0
             prefill_inflight = 0
             decode_prealloc = 0
@@ -182,6 +188,9 @@ class SchedulerLoadInquirer:
 
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 mode_str = "prefill"
+                prefill_pending = len(
+                    self.get_disagg_prefill_bootstrap_queue().pending_queue
+                )
                 prefill_bootstrap = len(self.get_disagg_prefill_bootstrap_queue().queue)
                 prefill_inflight = len(self.get_disagg_prefill_inflight_queue())
             elif self.disaggregation_mode == DisaggregationMode.DECODE:
@@ -194,6 +203,7 @@ class SchedulerLoadInquirer:
 
             disaggregation = DisaggregationMetrics(
                 mode=mode_str,
+                prefill_pending_queue_reqs=prefill_pending,
                 prefill_bootstrap_queue_reqs=prefill_bootstrap,
                 prefill_inflight_queue_reqs=prefill_inflight,
                 decode_prealloc_queue_reqs=decode_prealloc,

--- a/python/sglang/srt/mem_cache/allocator/hisparse.py
+++ b/python/sglang/srt/mem_cache/allocator/hisparse.py
@@ -1,4 +1,5 @@
 import weakref
+from typing import Tuple
 
 import torch
 
@@ -10,6 +11,27 @@ from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
 )
 from sglang.srt.mem_cache.hisparse_memory_pool import HiSparseDSATokenToKVPool
 from sglang.srt.utils.common import get_num_new_pages
+
+
+def _hisparse_backup_state(
+    logical_allocator, hisparse_allocator, mapping: torch.Tensor
+) -> Tuple:
+    return (
+        logical_allocator.backup_state(),
+        hisparse_allocator.backup_state(),
+        mapping.clone(),
+    )
+
+
+def _hisparse_restore_state(
+    logical_allocator, hisparse_allocator, mapping: torch.Tensor, state: Tuple
+) -> None:
+    logical_state, hisparse_state, mapping_snapshot = state
+    logical_allocator.restore_state(logical_state)
+    hisparse_allocator.restore_state(hisparse_state)
+    mapping[: mapping_snapshot.shape[0]].copy_(mapping_snapshot)
+    if mapping_snapshot.shape[0] < mapping.shape[0]:
+        mapping[mapping_snapshot.shape[0] :] = 0
 
 
 class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
@@ -163,6 +185,51 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def get_last_loc_hisparse_device(self, last_locs: torch.Tensor):
         return self._kvcache._translate_loc_to_hisparse_device(last_locs)
 
+    def alloc_extend_with_device_mapping(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        device_slots: torch.Tensor,
+        backup_state: bool = False,
+    ):
+        """Allocate logical indices and map them to caller-managed HiSparse slots."""
+        avail = self.logical_attn_allocator.available_size()
+        if avail < extend_num_tokens:
+            raise RuntimeError(
+                f"HiSparse logical alloc: need {extend_num_tokens} tokens but only "
+                f"{avail} are available."
+            )
+
+        logical_state = (
+            self.logical_attn_allocator.backup_state() if backup_state else None
+        )
+        out = self.logical_attn_allocator.alloc_extend(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+        )
+        if out is None:
+            raise RuntimeError(
+                f"HiSparse logical alloc failed for {extend_num_tokens} tokens. "
+                f"Logical pool available: {self.logical_attn_allocator.available_size()}"
+            )
+
+        self.full_to_hisparse_device_index_mapping[out] = device_slots
+        if backup_state:
+            return out, (logical_state, out.clone())
+        return out
+
+    def clear_device_mapping(self, logical_indices: torch.Tensor):
+        """Clear mappings for caller-managed slots before freeing logical indices."""
+        self.full_to_hisparse_device_index_mapping[logical_indices] = 0
+
     def alloc_extend(
         self,
         prefix_lens: torch.Tensor,
@@ -259,6 +326,26 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert (
             self.hisparse_attn_allocator.available_size()
             <= self.hisparse_attn_allocator.size
+        )
+
+    def backup_state(self):
+        return _hisparse_backup_state(
+            self.logical_attn_allocator,
+            self.hisparse_attn_allocator,
+            self.full_to_hisparse_device_index_mapping,
+        )
+
+    def restore_state(self, state):
+        if len(state) == 2:
+            # Draft extra-page mappings must stay live until accepted tokens are finalized.
+            self.logical_attn_allocator.restore_state(state[0])
+            return
+
+        _hisparse_restore_state(
+            self.logical_attn_allocator,
+            self.hisparse_attn_allocator,
+            self.full_to_hisparse_device_index_mapping,
+            state,
         )
 
 
@@ -562,4 +649,19 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert (
             self.hisparse_attn_allocator.available_size()
             <= self.hisparse_attn_allocator.size
+        )
+
+    def backup_state(self):
+        return _hisparse_backup_state(
+            self.logical_attn_allocator,
+            self.hisparse_attn_allocator,
+            self.full_to_hisparse_device_index_mapping,
+        )
+
+    def restore_state(self, state):
+        _hisparse_restore_state(
+            self.logical_attn_allocator,
+            self.hisparse_attn_allocator,
+            self.full_to_hisparse_device_index_mapping,
+            state,
         )

--- a/python/sglang/srt/mem_cache/allocator/hisparse.py
+++ b/python/sglang/srt/mem_cache/allocator/hisparse.py
@@ -197,11 +197,21 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         backup_state: bool = False,
     ):
         """Allocate logical indices and map them to caller-managed HiSparse slots."""
-        avail = self.logical_attn_allocator.available_size()
-        if avail < extend_num_tokens:
+        num_new_pages = get_num_new_pages(
+            seq_lens=seq_lens_cpu,
+            page_size=self.page_size,
+            prefix_lens=prefix_lens_cpu,
+        )
+        if self.logical_attn_allocator.need_sort and num_new_pages > len(
+            self.logical_attn_allocator.free_pages
+        ):
+            self.logical_attn_allocator.merge_and_sort_free()
+        avail_pages = len(self.logical_attn_allocator.free_pages)
+        if num_new_pages > avail_pages:
             raise RuntimeError(
-                f"HiSparse logical alloc: need {extend_num_tokens} tokens but only "
-                f"{avail} are available."
+                f"HiSparse logical alloc: need {num_new_pages} new pages for "
+                f"{extend_num_tokens} tokens but only {avail_pages} pages are "
+                "available."
             )
 
         logical_state = (

--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -65,7 +65,9 @@ class HiSparseDSATokenToKVPool(DSATokenToKVPool):
         )
 
     def translate_loc_to_hisparse_device(self, compressed_indices: torch.Tensor):
-        return self.full_to_hisparse_device_index_mapping[compressed_indices]
+        return self.full_to_hisparse_device_index_mapping[compressed_indices].to(
+            torch.int32
+        )
 
     def _translate_loc_to_hisparse_device(self, compressed_indices: torch.Tensor):
         return self.full_to_hisparse_device_index_mapping[compressed_indices]

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -263,13 +263,13 @@ class ReqToTokenPool:
         offset = 0
         for r in reqs:
             if r.req_pool_idx is None:
-                r.req_pool_idx = select_index[offset]
+                r.req_pool_idx = int(select_index[offset])
                 offset += 1
-        return [r.req_pool_idx for r in reqs]
+        return [int(r.req_pool_idx) for r in reqs]
 
     def free(self, req: Req):
         assert req.req_pool_idx is not None, "request must have req_pool_idx"
-        self.free_slots.append(req.req_pool_idx)
+        self.free_slots.append(int(req.req_pool_idx))
         req.req_pool_idx = None
 
     def clear(self):

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -68,6 +68,7 @@ from sglang.srt.utils.common import ceil_align, is_pin_memory_available
 if TYPE_CHECKING:
     from sglang.srt.layers.logits_processor import LogitsProcessorOutput
     from sglang.srt.layers.utils.cp_utils import ContextParallelMetadata
+    from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
     from sglang.srt.managers.schedule_batch import MultimodalInputs, ScheduleBatch
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
@@ -361,6 +362,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     sampling_info: SamplingBatchInfo = None
     # Speculative decoding
     spec_info: Optional[SpecInput] = None
+    # HiSparse coordinator propagated from ScheduleBatch / target worker.
+    hisparse_coordinator: Optional[HiSparseCoordinator] = None
 
     # === Derived from ScheduleBatch.reqs ===
     # For LoRA
@@ -644,6 +647,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             capture_hidden_mode=capture_hidden_mode,
             return_hidden_states_before_norm=return_hidden_states_before_norm,
             tbo_split_seq_index=batch.tbo_split_seq_index,
+            hisparse_coordinator=batch.hisparse_coordinator,
             # Host-side metadata
             top_logprobs_nums=batch.top_logprobs_nums,
             token_ids_logprobs=batch.token_ids_logprobs,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3630,6 +3630,20 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         else:
             ctx_mgr = forward_context(ForwardContext(attn_backend=self.attn_backend))
         with ctx_mgr:
+            active_hisparse_coordinator = self.hisparse_coordinator
+            if (
+                active_hisparse_coordinator is None
+                and forward_batch.hisparse_coordinator is not None
+                and callable(
+                    getattr(
+                        self.token_to_kv_pool,
+                        "translate_loc_to_hisparse_device",
+                        None,
+                    )
+                )
+            ):
+                active_hisparse_coordinator = forward_batch.hisparse_coordinator
+
             mode_check = (
                 forward_batch.forward_mode.is_cpu_graph
                 if self.device == "cpu"
@@ -3643,11 +3657,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
             if (
                 forward_batch.forward_mode.is_decode()
-                and self.hisparse_coordinator is not None
+                and active_hisparse_coordinator is not None
             ):
-                forward_batch.hisparse_coordinator = self.hisparse_coordinator
-                self.hisparse_coordinator.wait_for_pending_backup()
-                self.hisparse_coordinator.num_real_reqs.fill_(forward_batch.batch_size)
+                forward_batch.hisparse_coordinator = active_hisparse_coordinator
+                active_hisparse_coordinator.wait_for_pending_backup()
+                active_hisparse_coordinator.num_real_reqs.fill_(
+                    forward_batch.batch_size
+                )
 
             # Replay cuda graph if applicable
             if can_run_graph:
@@ -3681,8 +3697,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 )
 
             # Hisparse coordinator — backends now read it from self.model_runner.
-            if self.hisparse_coordinator is not None:
-                self.hisparse_coordinator.num_real_reqs.fill_(forward_batch.batch_size)
+            forward_batch.hisparse_coordinator = active_hisparse_coordinator
+            if active_hisparse_coordinator is not None:
+                active_hisparse_coordinator.num_real_reqs.fill_(
+                    forward_batch.batch_size
+                )
 
             # Forward without cuda graph
             if forward_batch.forward_mode.is_decode():

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -898,6 +898,39 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.init_cublas()
             self.init_attention_backend()
             self.kernel_warmup()
+            # Init hisparse coordinator (must happen before CUDA graph capture).
+            # Only the target runner owns scheduler-populated staging state.
+            if self.enable_hisparse and not self.is_draft_worker:
+                from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+                from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+
+                hisparse_cfg = parse_hisparse_config(self.server_args)
+                hisparse_top_k = getattr(
+                    self.model_config.hf_text_config, "index_topk", hisparse_cfg.top_k
+                )
+                hisparse_host_allocator_type = (
+                    "mooncake"
+                    if (
+                        self.server_args.disaggregation_mode == "decode"
+                        and self.server_args.disaggregation_transfer_backend
+                        == "mooncake"
+                    )
+                    else "default"
+                )
+                self.hisparse_coordinator = HiSparseCoordinator(
+                    req_to_token_pool=self.req_to_token_pool,
+                    token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                    top_k=hisparse_top_k,
+                    device_buffer_size=hisparse_cfg.device_buffer_size,
+                    device=self.device,
+                    tp_group=(
+                        self.attention_tp_group.cpu_group
+                        if self.server_args.enable_dp_attention
+                        else self.tp_group.cpu_group
+                    ),
+                    host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
+                    host_allocator_type=hisparse_host_allocator_type,
+                )
             self._pre_initialize_flashinfer_allreduce_workspace()
             if not disable_cuda_graph:
                 self.init_decode_cuda_graph()

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -834,6 +834,18 @@ class ModelRunnerKVCacheMixin:
                 self.token_to_kv_pool.full_to_swa_index_mapping = (
                     swa_allocator.full_to_swa_index_mapping
                 )
+            if self.enable_hisparse:
+                if isinstance(
+                    self.token_to_kv_pool_allocator, HiSparseTokenToKVPoolAllocator
+                ):
+                    self.token_to_kv_pool.full_to_hisparse_device_index_mapping = (
+                        self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+                    )
+                else:
+                    assert isinstance(
+                        self.token_to_kv_pool_allocator,
+                        DeepSeekV4HiSparseTokenToKVPoolAllocator,
+                    )
 
         # Defensive check: the explicit validation above should reject known
         # unsupported pool families before allocation. Keep this guard here so

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7879,6 +7879,33 @@ class ServerArgs:
 
         validate_hisparse(self)
 
+        if self.enable_hisparse and self.speculative_algorithm is not None:
+            from sglang.srt.configs.model_config import is_deepseek_nsa
+
+            if is_deepseek_nsa(self.get_model_config().hf_config):
+                from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+
+                hisparse_cfg = parse_hisparse_config(self)
+                hisparse_page_size = getattr(hisparse_cfg, "page_size", None)
+                if hisparse_page_size is None:
+                    hisparse_page_size = 64
+                max_draft = self.speculative_num_draft_tokens or 0
+                if max_draft >= hisparse_page_size:
+                    raise ValueError(
+                        f"hiSparse extra page capacity ({hisparse_page_size - 1} slots) "
+                        f"is insufficient for speculative_num_draft_tokens={max_draft}. "
+                        f"Reduce draft tokens or increase hiSparse page_size."
+                    )
+                if (
+                    self.speculative_eagle_topk is not None
+                    and self.speculative_eagle_topk > 1
+                    and self.page_size > 1
+                ):
+                    raise ValueError(
+                        "HiSparse + speculative topk > 1 + page_size > 1 is not yet "
+                        "supported. Use speculative_eagle_topk=1 or page_size=1."
+                    )
+
         assert (
             self.schedule_conservativeness >= 0
         ), "schedule_conservativeness must be non-negative"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7880,9 +7880,9 @@ class ServerArgs:
         validate_hisparse(self)
 
         if self.enable_hisparse and self.speculative_algorithm is not None:
-            from sglang.srt.configs.model_config import is_deepseek_nsa
+            from sglang.srt.configs.model_config import is_deepseek_dsa
 
-            if is_deepseek_nsa(self.get_model_config().hf_config):
+            if is_deepseek_dsa(self.get_model_config().hf_config):
                 from sglang.srt.mem_cache.sparsity import parse_hisparse_config
 
                 hisparse_cfg = parse_hisparse_config(self)

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -251,6 +251,26 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
         # EAGLE doesn't use stream_idx / lora variants.
         return ShapeKey(size=bs)
 
+    def _attach_hisparse_coordinator(
+        self, forward_batch: ForwardBatch, num_real_reqs: int
+    ) -> None:
+        target_worker = getattr(self.eagle_worker, "target_worker", None)
+        target_model_runner = getattr(target_worker, "model_runner", None)
+        coordinator = getattr(target_model_runner, "hisparse_coordinator", None)
+        if coordinator is None:
+            return
+        if not callable(
+            getattr(
+                self.model_runner.token_to_kv_pool,
+                "translate_loc_to_hisparse_device",
+                None,
+            )
+        ):
+            return
+        forward_batch.hisparse_coordinator = coordinator
+        coordinator.wait_for_pending_backup()
+        coordinator.num_real_reqs.fill_(num_real_reqs)
+
     # -----------------------------------------------------------------
     # can_run
     # -----------------------------------------------------------------
@@ -374,6 +394,8 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
                 spec_info.capture_hidden_mode if spec_info else CaptureHiddenMode.NULL
             ),
         )
+
+        self._attach_hisparse_coordinator(forward_batch, num_seqs)
 
         def run_once():
             self.draft_attn_backend.init_forward_metadata_in_graph(forward_batch)
@@ -521,6 +543,7 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             forward_batch.seq_lens_cpu = buffers.seq_lens_cpu[:bs]
 
         # forward_batch.batch_size was overwritten to bs above when padding.
+        self._attach_hisparse_coordinator(forward_batch, raw_bs)
         self.draft_attn_backend.init_forward_metadata_out_graph(forward_batch)
         self.raw_bs = raw_bs
         self.bs = bs

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -254,7 +254,47 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
     def _make_graph_key(self, bs, stream_idx=None, variant_label=None):
         return ShapeKey(size=bs)
 
+    def _uses_target_hisparse_coordinator(self, forward_batch: ForwardBatch) -> bool:
+        target_worker = getattr(self.eagle_worker, "target_worker", None)
+        target_model_runner = getattr(target_worker, "model_runner", None)
+        coordinator = getattr(target_model_runner, "hisparse_coordinator", None)
+        if coordinator is None:
+            return False
+        return callable(
+            getattr(
+                self.model_runner.token_to_kv_pool,
+                "translate_loc_to_hisparse_device",
+                None,
+            )
+        )
+
+    def _attach_hisparse_coordinator(
+        self, forward_batch: ForwardBatch, num_real_reqs: int
+    ) -> None:
+        target_worker = getattr(self.eagle_worker, "target_worker", None)
+        target_model_runner = getattr(target_worker, "model_runner", None)
+        coordinator = getattr(target_model_runner, "hisparse_coordinator", None)
+        if coordinator is None:
+            return
+        if not callable(
+            getattr(
+                self.model_runner.token_to_kv_pool,
+                "translate_loc_to_hisparse_device",
+                None,
+            )
+        ):
+            return
+        forward_batch.hisparse_coordinator = coordinator
+        coordinator.wait_for_pending_backup()
+        coordinator.num_real_reqs.fill_(num_real_reqs)
+
     def can_run(self, forward_batch: ForwardBatch):
+        if self._uses_target_hisparse_coordinator(forward_batch):
+            # HiSparse draft-extend uses per-request variable accepted-token
+            # counts. The captured graph has a fixed full-row layout, so replay
+            # can reinterpret packed rows incorrectly after verify.
+            return False
+
         if self.require_mlp_tp_gather:
             cuda_graph_bs = (
                 max(forward_batch.global_num_tokens_cpu) // self.num_tokens_per_bs
@@ -365,6 +405,8 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             capture_hidden_mode=CaptureHiddenMode.LAST,
             padded_static_len=self.padded_static_len,
         )
+
+        self._attach_hisparse_coordinator(forward_batch, bs)
 
         def run_once():
             # Clean intermediate result cache for DP attention
@@ -514,6 +556,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         seq_lens_sum = forward_batch.seq_lens_sum
         if seq_lens_sum is not None:
             seq_lens_sum = seq_lens_sum + (bs - raw_bs) * self.seq_len_fill_value
+        self._attach_hisparse_coordinator(forward_batch, raw_bs)
         fb_view = SimpleNamespace(
             batch_size=bs,
             forward_mode=self.forward_mode,
@@ -525,6 +568,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             encoder_lens=None,
             out_cache_loc=forward_batch.out_cache_loc,
             spec_info=forward_batch.spec_info,
+            hisparse_coordinator=forward_batch.hisparse_coordinator,
         )
         self.draft_extend_attn_backend.init_forward_metadata_out_graph(fb_view)
 

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -260,9 +260,10 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         coordinator = getattr(target_model_runner, "hisparse_coordinator", None)
         if coordinator is None:
             return False
+        token_to_kv_pool = getattr(forward_batch, "token_to_kv_pool", None)
         return callable(
             getattr(
-                self.model_runner.token_to_kv_pool,
+                token_to_kv_pool,
                 "translate_loc_to_hisparse_device",
                 None,
             )
@@ -276,9 +277,10 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         coordinator = getattr(target_model_runner, "hisparse_coordinator", None)
         if coordinator is None:
             return
+        token_to_kv_pool = getattr(forward_batch, "token_to_kv_pool", None)
         if not callable(
             getattr(
-                self.model_runner.token_to_kv_pool,
+                token_to_kv_pool,
                 "translate_loc_to_hisparse_device",
                 None,
             )

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -9,6 +9,7 @@ from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_token_slots,
+    evict_from_tree_cache,
     get_alloc_reserve_per_decode,
     get_last_loc,
 )
@@ -105,15 +106,40 @@ class EagleDraftInputV2Mixin:
                 batch.req_pool_indices,
                 cur_kv_lens_device,
             )
-            out_cache_loc = alloc_paged_token_slots_extend(
-                batch.tree_cache,
-                cur_kv_lens_device,
-                cur_kv_lens_cpu,
-                nxt_kv_lens_device,
-                nxt_kv_lens_cpu,
-                last_loc,
-                num_needed_tokens,
-            )
+            hisparse_coordinator = batch.hisparse_coordinator
+            if (
+                hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                allocator = batch.tree_cache.token_to_kv_pool_allocator
+                evict_from_tree_cache(
+                    batch.tree_cache,
+                    num_needed_tokens + len(cur_kv_lens_cpu) * allocator.page_size,
+                )
+                device_slots = hisparse_coordinator.get_draft_device_slots_variable(
+                    batch.req_pool_indices,
+                    nxt_kv_lens_cpu - cur_kv_lens_cpu,
+                    cur_kv_lens_cpu,
+                )
+                out_cache_loc = allocator.alloc_extend_with_device_mapping(
+                    cur_kv_lens_device,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens_device,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                    device_slots,
+                )
+            else:
+                out_cache_loc = alloc_paged_token_slots_extend(
+                    batch.tree_cache,
+                    cur_kv_lens_device,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens_device,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                )
 
         assign_req_to_token_pool_func(
             batch.req_pool_indices,

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -314,6 +314,17 @@ def eagle_prepare_for_verify(
             draft_token_num=verify_input.draft_token_num,
             device=device,
         )
+        hisparse_coordinator = batch.hisparse_coordinator
+        if (
+            hisparse_coordinator is not None
+            and hisparse_coordinator.supports_hisparse_draft_slots()
+        ):
+            hisparse_coordinator.prepare_verify_slots_spec_v2(
+                req_pool_indices=batch.req_pool_indices,
+                verify_cache_locs=batch.out_cache_loc,
+                num_tokens_per_req=verify_input.draft_token_num,
+                start_positions_cpu=batch.seq_lens_cpu,
+            )
 
         prepare_mamba_track_for_verify(batch)
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1420,6 +1420,19 @@ class EAGLEWorkerV2(BaseSpecWorker):
         ) = eagle_sample(verify_input, batch, logits_output, vocab_mask)
         new_seq_lens = batch.seq_lens + accept_lens
 
+        hisparse_coordinator = batch.hisparse_coordinator
+        if (
+            hisparse_coordinator is not None
+            and hisparse_coordinator.supports_hisparse_draft_slots()
+            and not batch.forward_mode.is_idle()
+        ):
+            hisparse_coordinator.finalize_accepted_tokens_spec_v2(
+                req_pool_indices=batch.req_pool_indices,
+                seq_lens=batch.seq_lens,
+                verify_cache_locs=batch.out_cache_loc,
+                accept_index=accept_index,
+            )
+
         # Update mamba state for hybrid GDN models after verification
         commit_mamba_states_after_verify(
             self.target_worker,

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -76,6 +76,32 @@ struct PDRequestContext<'a> {
 #[derive(Clone, Copy)]
 struct BreakerOutcomesRecorded;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorkerDispatchOutcome {
+    Http(StatusCode),
+    TransportError,
+}
+
+impl WorkerDispatchOutcome {
+    fn from_result(result: &Result<reqwest::Response, reqwest::Error>) -> Self {
+        match result {
+            Ok(response) => Self::Http(response.status()),
+            Err(_) => Self::TransportError,
+        }
+    }
+
+    fn is_server_or_transport_error(self) -> bool {
+        match self {
+            Self::Http(status) => status.is_server_error(),
+            Self::TransportError => true,
+        }
+    }
+
+    fn is_success(self) -> bool {
+        matches!(self, Self::Http(status) if status.is_success())
+    }
+}
+
 impl PDRouter {
     async fn proxy_to_first_prefill_worker(
         &self,
@@ -190,6 +216,75 @@ impl PDRouter {
     fn handle_serialization_error(error: impl std::fmt::Display) -> Response {
         error!("Failed to serialize request error={}", error);
         error::internal_error("serialization_failed", "Failed to serialize request")
+    }
+
+    fn record_worker_http_status(
+        worker: &Arc<dyn Worker>,
+        worker_label: &'static str,
+        status: StatusCode,
+    ) {
+        let not_error = status.is_success() || status.is_client_error();
+        worker.record_outcome(not_error);
+
+        if status.is_server_error() {
+            Metrics::record_worker_error(
+                worker_label,
+                metrics_labels::CONNECTION_HTTP,
+                error_type_from_status(status),
+            );
+        }
+    }
+
+    fn record_worker_transport_error(worker: &Arc<dyn Worker>, worker_label: &'static str) {
+        worker.record_outcome(false);
+        Metrics::record_worker_error(
+            worker_label,
+            metrics_labels::CONNECTION_HTTP,
+            error_type_from_status(StatusCode::BAD_GATEWAY),
+        );
+    }
+
+    fn record_worker_dispatch_outcome(
+        worker: &Arc<dyn Worker>,
+        worker_label: &'static str,
+        outcome: WorkerDispatchOutcome,
+    ) {
+        match outcome {
+            WorkerDispatchOutcome::Http(status) => {
+                Self::record_worker_http_status(worker, worker_label, status)
+            }
+            WorkerDispatchOutcome::TransportError => {
+                Self::record_worker_transport_error(worker, worker_label)
+            }
+        }
+    }
+
+    fn record_pd_worker_outcomes(
+        prefill: &Arc<dyn Worker>,
+        decode: &Arc<dyn Worker>,
+        prefill_outcome: WorkerDispatchOutcome,
+        decode_outcome: WorkerDispatchOutcome,
+    ) {
+        Self::record_worker_dispatch_outcome(decode, metrics_labels::WORKER_DECODE, decode_outcome);
+
+        if decode_outcome.is_server_or_transport_error()
+            && prefill_outcome.is_server_or_transport_error()
+        {
+            debug!(
+                prefill_url = prefill.url(),
+                decode_url = decode.url(),
+                ?prefill_outcome,
+                ?decode_outcome,
+                "Skipping prefill circuit failure because decode request already failed"
+            );
+            return;
+        }
+
+        Self::record_worker_dispatch_outcome(
+            prefill,
+            metrics_labels::WORKER_PREFILL,
+            prefill_outcome,
+        );
     }
 
     fn get_generate_batch_size(req: &GenerateRequest) -> Option<usize> {
@@ -593,7 +688,7 @@ impl PDRouter {
             context.route,
             &json_request,
             headers,
-            false,
+            true,
         );
         let decode_request = self.build_post_with_headers(
             &self.client,
@@ -601,19 +696,109 @@ impl PDRouter {
             context.route,
             &json_request,
             headers,
-            false,
+            true,
         );
 
-        // Send both requests concurrently and wait for both
-        // Note: Using borrowed references avoids heap allocation
+        // Send both requests concurrently. Prefill is the dependency that can
+        // unblock decode KV transfer, so fail fast on prefill send/status errors
+        // instead of waiting for decode to time out with no KV cache.
         events::RequestPDSentEvent {
             prefill_url: prefill.url(),
             decode_url: decode.url(),
         }
         .emit();
 
-        let (prefill_result, decode_result) =
-            tokio::join!(prefill_request.send(), decode_request.send());
+        let prefill_task = tokio::spawn(prefill_request.send());
+        let decode_task = tokio::spawn(decode_request.send());
+
+        let prefill_result = match prefill_task.await {
+            Ok(result) => result,
+            Err(e) => {
+                decode_task.abort();
+                let _ = decode_task.await;
+                Self::record_worker_dispatch_outcome(
+                    &prefill,
+                    metrics_labels::WORKER_PREFILL,
+                    WorkerDispatchOutcome::TransportError,
+                );
+                error!(
+                    prefill_url = %prefill.url(),
+                    error = %e,
+                    "Prefill request task failed"
+                );
+                let mut response = error::bad_gateway(
+                    "prefill_server_error",
+                    format!("Prefill request task failed: {}", e),
+                );
+                response.extensions_mut().insert(BreakerOutcomesRecorded);
+                return response;
+            }
+        };
+
+        let prefill_outcome = WorkerDispatchOutcome::from_result(&prefill_result);
+        if !prefill_outcome.is_success() {
+            decode_task.abort();
+            let _ = decode_task.await;
+            Self::record_worker_dispatch_outcome(
+                &prefill,
+                metrics_labels::WORKER_PREFILL,
+                prefill_outcome,
+            );
+            let mut response = match self
+                .process_prefill_response(prefill_result, prefill.url(), context.return_logprob)
+                .await
+            {
+                Ok((_, _)) => error::bad_gateway(
+                    "prefill_server_error",
+                    "Prefill request did not complete successfully",
+                ),
+                Err(error_response) => error_response,
+            };
+            response.extensions_mut().insert(BreakerOutcomesRecorded);
+            return response;
+        }
+
+        let prefill_body = match self
+            .process_prefill_response(prefill_result, prefill.url(), context.return_logprob)
+            .await
+        {
+            Ok((_, body)) => body,
+            Err(error_response) => {
+                decode_task.abort();
+                let _ = decode_task.await;
+                Self::record_worker_dispatch_outcome(
+                    &prefill,
+                    metrics_labels::WORKER_PREFILL,
+                    prefill_outcome,
+                );
+                let mut response = error_response;
+                response.extensions_mut().insert(BreakerOutcomesRecorded);
+                return response;
+            }
+        };
+
+        let decode_result = match decode_task.await {
+            Ok(result) => result,
+            Err(e) => {
+                Self::record_pd_worker_outcomes(
+                    &prefill,
+                    &decode,
+                    prefill_outcome,
+                    WorkerDispatchOutcome::TransportError,
+                );
+                error!(
+                    decode_url = %decode.url(),
+                    error = %e,
+                    "Decode request task failed"
+                );
+                let mut response = error::bad_gateway(
+                    "decode_server_error",
+                    format!("Decode request task failed: {}", e),
+                );
+                response.extensions_mut().insert(BreakerOutcomesRecorded);
+                return response;
+            }
+        };
 
         events::RequestReceivedEvent {}.emit();
 
@@ -631,33 +816,12 @@ impl PDRouter {
                         status
                     );
 
-                    // Per-worker breaker attribution before the synthetic 5xx
-                    // response takes over. Prefill ran concurrently in the
-                    // `tokio::join!`: tick it based on its actual response
-                    // status, not on the decode-driven failure. For
-                    // non-streaming the response carries no tracked stream
-                    // so record decode's outcome here too — but treat 4xx
-                    // as a client fault rather than a worker fault, matching
-                    // the legacy outer-dispatcher rule and the streaming
-                    // `BreakerTrackedStream` pre-mark in
-                    // `create_streaming_response`. For streaming
-                    // `handle_decode_error_response` wraps the synthetic
-                    // error SSE in a `BreakerTrackedStream` that ticks
-                    // decode on drop, so skip to avoid double-counting.
-                    // Mark the response so the outer dispatcher skips its
-                    // status-derived `record_outcome`.
-                    let prefill_ok = match &prefill_result {
-                        Ok(r) => {
-                            let s = r.status();
-                            s.is_success() || s.is_client_error()
-                        }
-                        Err(_) => false,
-                    };
-                    prefill.record_outcome(prefill_ok);
-                    if !context.is_stream {
-                        let decode_ok = status.is_success() || status.is_client_error();
-                        decode.record_outcome(decode_ok);
-                    }
+                    Self::record_pd_worker_outcomes(
+                        &prefill,
+                        &decode,
+                        prefill_outcome,
+                        WorkerDispatchOutcome::Http(status),
+                    );
 
                     let mut response = self
                         .handle_decode_error_response(res, &context, prefill, decode)
@@ -665,30 +829,6 @@ impl PDRouter {
                     response.extensions_mut().insert(BreakerOutcomesRecorded);
                     return response;
                 }
-
-                // Process prefill response
-                let prefill_body = if context.return_logprob {
-                    match self
-                        .process_prefill_response(
-                            prefill_result,
-                            prefill.url(),
-                            context.return_logprob,
-                        )
-                        .await
-                    {
-                        Ok((_, body)) => body,
-                        Err(error_response) => return error_response,
-                    }
-                } else {
-                    // Even if we don't need logprobs, we should check prefill status
-                    match self
-                        .process_prefill_response(prefill_result, prefill.url(), false)
-                        .await
-                    {
-                        Ok((_, body)) => body,
-                        Err(error_response) => return error_response,
-                    }
-                };
 
                 if context.is_stream {
                     // Streaming response
@@ -753,26 +893,12 @@ impl PDRouter {
                     error = %e,
                     "Decode request failed"
                 );
-                // Decode failed at TCP/transport level. No tracked
-                // stream will ever wrap a response (streaming path) and
-                // we shortcut past the outer non-streaming
-                // `record_outcome` too — so record decode failure
-                // directly. Prefill ran concurrently in the
-                // `tokio::join!`: record its real per-worker outcome
-                // (success on a 2xx/4xx send, failure on transport
-                // error) so the decode-driven 502 doesn't penalise a
-                // healthy prefill. Mark the response so the outer
-                // dispatcher skips its status-derived `record_outcome`
-                // and we don't double-count.
-                decode.record_outcome(false);
-                let prefill_ok = match &prefill_result {
-                    Ok(res) => {
-                        let s = res.status();
-                        s.is_success() || s.is_client_error()
-                    }
-                    Err(_) => false,
-                };
-                prefill.record_outcome(prefill_ok);
+                Self::record_pd_worker_outcomes(
+                    &prefill,
+                    &decode,
+                    prefill_outcome,
+                    WorkerDispatchOutcome::TransportError,
+                );
 
                 let mut response = error::bad_gateway(
                     "decode_server_error",
@@ -893,10 +1019,30 @@ impl PDRouter {
             .collect();
 
         if available_workers.is_empty() {
-            return Err(format!(
-                "No available {} workers (all circuits open or unhealthy)",
-                worker_type
-            ));
+            let healthy_workers: Vec<Arc<dyn Worker>> =
+                workers.iter().filter(|w| w.is_healthy()).cloned().collect();
+
+            if healthy_workers.is_empty() {
+                return Err(format!(
+                    "No available {} workers (all circuits open or unhealthy)",
+                    worker_type
+                ));
+            }
+
+            warn!(
+                worker_type = worker_type,
+                healthy_worker_count = healthy_workers.len(),
+                "All healthy PD workers are circuit-open; falling back to lowest-load health-only selection"
+            );
+            return healthy_workers
+                .into_iter()
+                .min_by_key(|worker| worker.load())
+                .ok_or_else(|| {
+                    format!(
+                        "No available {} workers (all circuits open or unhealthy)",
+                        worker_type
+                    )
+                });
         }
 
         let selected_idx = policy
@@ -1092,7 +1238,7 @@ impl PDRouter {
             Ok(response) => response,
             Err(e) => {
                 error!(
-                    "Prefill server failed (CRITICAL) prefill_url={} error={}. Decode will timeout without prefill KV cache.",
+                    "Prefill server failed (CRITICAL) prefill_url={} error={}. Aborting decode dispatch before it waits for missing KV cache.",
                     prefill_url,
                     e
                 );
@@ -1100,10 +1246,7 @@ impl PDRouter {
                 // Return error immediately - don't wait for decode to timeout
                 return Err(error::bad_gateway(
                     "prefill_server_error",
-                    format!(
-                        "Prefill server error: {}. This will cause decode timeout.",
-                        e
-                    ),
+                    format!("Prefill server error: {}. Decode dispatch was aborted.", e),
                 ));
             }
         };
@@ -1645,6 +1788,144 @@ mod tests {
 
         assert_eq!(prefill_worker.load(), 0);
         assert_eq!(decode_worker.load(), 0);
+    }
+
+    #[test]
+    fn test_decode_server_error_does_not_open_prefill_circuit() {
+        let prefill_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://prefill".to_string(),
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+            true,
+        ));
+        let decode_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+            true,
+        ));
+
+        for _ in 0..12 {
+            PDRouter::record_pd_worker_outcomes(
+                &prefill_worker,
+                &decode_worker,
+                WorkerDispatchOutcome::Http(StatusCode::INTERNAL_SERVER_ERROR),
+                WorkerDispatchOutcome::Http(StatusCode::INTERNAL_SERVER_ERROR),
+            );
+        }
+
+        assert!(prefill_worker.circuit_breaker().can_execute());
+        assert_eq!(prefill_worker.circuit_breaker().consecutive_failures(), 0);
+        assert!(!decode_worker.circuit_breaker().can_execute());
+    }
+
+    #[test]
+    fn test_prefill_server_error_opens_prefill_circuit_when_decode_succeeds() {
+        let prefill_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://prefill".to_string(),
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+            true,
+        ));
+        let decode_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+            true,
+        ));
+
+        for _ in 0..12 {
+            PDRouter::record_pd_worker_outcomes(
+                &prefill_worker,
+                &decode_worker,
+                WorkerDispatchOutcome::Http(StatusCode::INTERNAL_SERVER_ERROR),
+                WorkerDispatchOutcome::Http(StatusCode::OK),
+            );
+        }
+
+        assert!(!prefill_worker.circuit_breaker().can_execute());
+        assert!(decode_worker.circuit_breaker().can_execute());
+    }
+
+    #[test]
+    fn test_decode_server_error_records_prefill_success_when_prefill_succeeds() {
+        let prefill_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://prefill".to_string(),
+            WorkerType::Prefill {
+                bootstrap_port: None,
+            },
+            true,
+        ));
+        let decode_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+            true,
+        ));
+
+        PDRouter::record_pd_worker_outcomes(
+            &prefill_worker,
+            &decode_worker,
+            WorkerDispatchOutcome::Http(StatusCode::INTERNAL_SERVER_ERROR),
+            WorkerDispatchOutcome::Http(StatusCode::OK),
+        );
+        assert_eq!(prefill_worker.circuit_breaker().consecutive_failures(), 1);
+
+        PDRouter::record_pd_worker_outcomes(
+            &prefill_worker,
+            &decode_worker,
+            WorkerDispatchOutcome::Http(StatusCode::OK),
+            WorkerDispatchOutcome::Http(StatusCode::INTERNAL_SERVER_ERROR),
+        );
+
+        assert!(prefill_worker.circuit_breaker().can_execute());
+        assert_eq!(prefill_worker.circuit_breaker().consecutive_failures(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_pick_worker_falls_back_to_healthy_when_circuit_open() {
+        let router = create_test_pd_router();
+        let decode_worker: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+            true,
+        ));
+
+        for _ in 0..12 {
+            decode_worker.record_outcome(false);
+        }
+
+        assert!(decode_worker.is_healthy());
+        assert!(!decode_worker.is_available());
+
+        let workers = vec![decode_worker.clone()];
+        let policy = router.policy_registry.get_decode_policy();
+        let selected =
+            PDRouter::pick_worker_by_policy_arc(&workers, &*policy, None, None, None, "decode")
+                .await
+                .unwrap();
+
+        assert_eq!(selected.url(), "http://decode");
+    }
+
+    #[test]
+    fn test_build_post_with_headers_can_close_connection() {
+        let router = create_test_pd_router();
+        let request = router
+            .build_post_with_headers(
+                &router.client,
+                "http://prefill",
+                "/v1/chat/completions",
+                &serde_json::json!({"model": "test"}),
+                None,
+                true,
+            )
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request.headers().get("connection"),
+            Some(&HeaderValue::from_static("close"))
+        );
     }
 
     #[tokio::test]

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -9,6 +9,7 @@ from sglang.srt.disaggregation.decode import (
     HiCacheRestoreResult,
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.io_struct import AbortReq
 from sglang.srt.managers.schedule_batch import FINISH_ABORT
 from sglang.srt.managers.scheduler import Scheduler
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -19,7 +20,11 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 class FakeReceiver:
     def __init__(self):
+        self.abort_called = False
         self.clear_called = False
+
+    def abort(self):
+        self.abort_called = True
 
     def clear(self):
         self.clear_called = True
@@ -145,6 +150,66 @@ class TestDecodeQueueCleanup(CustomTestCase):
         scheduler.enable_hierarchical_cache = False
 
         self.assertFalse(scheduler.is_fully_idle())
+
+    @patch("sglang.srt.managers.scheduler.release_kv_cache")
+    def test_abort_decode_queues_sends_through_ipc_channels(
+        self, mock_release_kv_cache
+    ):
+        prealloc_receiver = FakeReceiver()
+        transfer_receiver = FakeReceiver()
+        prealloc_req = SimpleNamespace(rid="abort-prealloc")
+        transfer_req = SimpleNamespace(rid="abort-transfer", bootstrap_room=7)
+        prealloc_decode_req = SimpleNamespace(
+            req=prealloc_req, kv_receiver=prealloc_receiver
+        )
+        transfer_decode_req = SimpleNamespace(
+            req=transfer_req,
+            kv_receiver=transfer_receiver,
+            metadata_buffer_index=3,
+        )
+        metadata_allocator = MagicMock()
+        send_output = MagicMock()
+
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.waiting_queue = []
+        scheduler.grammar_manager = MagicMock()
+        scheduler.disaggregation_mode = DisaggregationMode.DECODE
+        scheduler.enable_hisparse = False
+        scheduler.disagg_decode_prealloc_queue = SimpleNamespace(
+            queue=[prealloc_decode_req],
+            pending_reqs=[prealloc_decode_req],
+            retracted_queue=[],
+        )
+        scheduler.disagg_decode_transfer_queue = SimpleNamespace(
+            queue=[transfer_decode_req],
+            enable_staging=False,
+            staging_handler=None,
+            req_to_metadata_buffer_idx_allocator=metadata_allocator,
+        )
+        scheduler.tree_cache = MagicMock()
+        scheduler.running_batch = SimpleNamespace(reqs=[])
+        scheduler.cur_batch = None
+        scheduler.ipc_channels = SimpleNamespace(
+            send_to_tokenizer=SimpleNamespace(send_output=send_output)
+        )
+
+        scheduler.abort_request(AbortReq(rid="abort"))
+
+        self.assertEqual(scheduler.disagg_decode_prealloc_queue.queue, [])
+        self.assertEqual(scheduler.disagg_decode_prealloc_queue.pending_reqs, [])
+        self.assertEqual(scheduler.disagg_decode_transfer_queue.queue, [])
+        self.assertTrue(prealloc_receiver.abort_called)
+        self.assertTrue(prealloc_receiver.clear_called)
+        self.assertTrue(transfer_receiver.abort_called)
+        self.assertTrue(transfer_receiver.clear_called)
+        metadata_allocator.free.assert_called_once_with(3)
+        self.assertEqual(transfer_decode_req.metadata_buffer_index, -1)
+        mock_release_kv_cache.assert_called_once_with(
+            transfer_req, scheduler.tree_cache, is_insert=False
+        )
+        self.assertEqual(send_output.call_count, 2)
+        self.assertEqual(send_output.call_args_list[0].args[1], prealloc_req)
+        self.assertEqual(send_output.call_args_list[1].args[1], transfer_req)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/disaggregation/test_mooncake_hisparse.py
+++ b/test/registered/unit/disaggregation/test_mooncake_hisparse.py
@@ -1,0 +1,51 @@
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+class TestMooncakeHiSparseTransfer(unittest.TestCase):
+    def test_hisparse_transfer_uses_only_target_kv_group(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.kv_args = SimpleNamespace(
+            page_size=4,
+            kv_data_ptrs=[100, 200, 300],
+            kv_item_lens=[40, 80, 120],
+            target_kv_data_ptr_count=2,
+        )
+        captured = {}
+
+        def capture_send(**kwargs):
+            captured.update(kwargs)
+            return 0
+
+        manager._send_kvcache_generic = capture_send
+
+        ret = manager.send_kvcache_hisparse(
+            mooncake_session_id="session",
+            prefill_kv_indices=np.array([5], dtype=np.int32),
+            dst_kv_ptrs=[1000, 2000],
+            dst_kv_indices=np.array([10, 11, 12, 13], dtype=np.int32),
+            page_index_slice=slice(0, 1),
+            executor=None,
+        )
+
+        self.assertEqual(ret, 0)
+        self.assertEqual(captured["src_data_ptrs"], [100, 200])
+        self.assertEqual(captured["dst_data_ptrs"], [1000, 2000])
+        self.assertEqual(captured["item_lens"], [10, 20])
+        np.testing.assert_array_equal(
+            captured["prefill_data_indices"], np.array([20, 21, 22, 23])
+        )
+        np.testing.assert_array_equal(
+            captured["dst_data_indices"], np.array([10, 11, 12, 13])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_prefill_bootstrap_admission.py
+++ b/test/registered/unit/disaggregation/test_prefill_bootstrap_admission.py
@@ -112,11 +112,19 @@ class TestPrefillBootstrapAdmission(unittest.TestCase):
             def check_status(self, bootstrap_room):
                 return KVPoll.Bootstrapping
 
+            def record_failure(self, bootstrap_room, reason):
+                raise AssertionError("bootstrap should not fail before timeout")
+
+            def update_status(self, bootstrap_room, status):
+                raise AssertionError("bootstrap should not update before timeout")
+
         sender = MooncakeKVSender.__new__(MooncakeKVSender)
         sender.conclude_state = None
         sender.kv_mgr = FakeKVManager()
         sender.bootstrap_room = 7
         sender.init_time = None
+        sender.transfer_init_time = None
+        sender.trace_ctx = SimpleNamespace(trace_req_finish=lambda: None)
 
         self.assertEqual(sender.poll(), KVPoll.Bootstrapping)
         self.assertIsNone(sender.init_time)
@@ -127,6 +135,74 @@ class TestPrefillBootstrapAdmission(unittest.TestCase):
         self.assertEqual(sender.poll(), KVPoll.Bootstrapping)
         self.assertIsNotNone(sender.init_time)
         self.assertGreaterEqual(sender.init_time, before_poll)
+
+    def test_mooncake_sender_bootstrap_timeout_fails_after_metadata_timeout(self):
+        class FakeKVManager:
+            bootstrap_timeout = 60.0
+
+            def __init__(self):
+                self.status = KVPoll.Bootstrapping
+                self.failures = []
+                self.transfer_infos = {7: {"session": object()}}
+
+            def check_status(self, bootstrap_room):
+                return self.status
+
+            def record_failure(self, bootstrap_room, reason):
+                self.failures.append((bootstrap_room, reason))
+
+            def update_status(self, bootstrap_room, status):
+                self.status = status
+
+        sender = MooncakeKVSender.__new__(MooncakeKVSender)
+        sender.conclude_state = None
+        sender.kv_mgr = FakeKVManager()
+        sender.bootstrap_room = 7
+        sender.init_time = time.time() - sender.kv_mgr.bootstrap_timeout - 1
+        sender.transfer_init_time = None
+        sender.trace_ctx = SimpleNamespace(trace_req_finish=lambda: None)
+
+        self.assertEqual(sender.poll(), KVPoll.Failed)
+        self.assertEqual(sender.kv_mgr.status, KVPoll.Failed)
+        self.assertIn("KVPoll.Bootstrapping", sender.kv_mgr.failures[0][1])
+
+    def test_mooncake_sender_transfer_timeout_fails_inflight_request(self):
+        class FakeKVManager:
+            waiting_timeout = 60.0
+
+            def __init__(self):
+                self.status = KVPoll.Transferring
+                self.failures = []
+
+            def check_status(self, bootstrap_room):
+                return self.status
+
+            def record_failure(self, bootstrap_room, reason):
+                self.failures.append((bootstrap_room, reason))
+
+            def update_status(self, bootstrap_room, status):
+                self.status = status
+
+        sender = MooncakeKVSender.__new__(MooncakeKVSender)
+        sender.conclude_state = None
+        sender.kv_mgr = FakeKVManager()
+        sender.bootstrap_room = 17
+        sender.init_time = None
+        sender.transfer_init_time = None
+        sender.trace_ctx = SimpleNamespace(trace_req_finish=lambda: None)
+
+        before_poll = time.time()
+
+        self.assertEqual(sender.poll(), KVPoll.Transferring)
+        self.assertIsNotNone(sender.transfer_init_time)
+        self.assertGreaterEqual(sender.transfer_init_time, before_poll)
+        self.assertEqual(sender.kv_mgr.failures, [])
+
+        sender.transfer_init_time = time.time() - sender.kv_mgr.waiting_timeout - 1
+
+        self.assertEqual(sender.poll(), KVPoll.Failed)
+        self.assertEqual(sender.kv_mgr.status, KVPoll.Failed)
+        self.assertIn("KVPoll.Transferring", sender.kv_mgr.failures[0][1])
 
     def test_mooncake_receiver_waiting_timeout_starts_after_transfer_begins(self):
         class FakeKVManager:
@@ -142,11 +218,15 @@ class TestPrefillBootstrapAdmission(unittest.TestCase):
             def record_failure(self, bootstrap_room, reason):
                 self.failures.append((bootstrap_room, reason))
 
+            def update_status(self, bootstrap_room, status):
+                self.status = status
+
         receiver = MooncakeKVReceiver.__new__(MooncakeKVReceiver)
         receiver.conclude_state = None
         receiver.kv_mgr = FakeKVManager()
         receiver.bootstrap_room = 11
         receiver.init_time = None
+        receiver.abort_notified = False
 
         self.assertEqual(receiver.poll(), KVPoll.WaitingForInput)
         self.assertIsNone(receiver.init_time)
@@ -162,7 +242,7 @@ class TestPrefillBootstrapAdmission(unittest.TestCase):
         receiver.init_time = time.time() - receiver.kv_mgr.waiting_timeout - 1
 
         self.assertEqual(receiver.poll(), KVPoll.Failed)
-        self.assertIn("KVPoll.Transferring", receiver.kv_mgr.failures[0][1])
+        self.assertIn("KVPoll.WaitingForInput", receiver.kv_mgr.failures[0][1])
 
     def test_mooncake_transfer_worker_drops_failed_room_without_transfer(self):
         class StopLoop(BaseException):
@@ -181,9 +261,11 @@ class TestPrefillBootstrapAdmission(unittest.TestCase):
 
         manager = SimpleNamespace()
         manager.enable_staging = False
+        manager.enable_trace = False
         manager.transfer_infos = {3: {"session": object()}}
         manager.req_to_decode_prefix_len = {3: 0}
         manager.request_status = {3: KVPoll.Failed}
+        manager.check_status = lambda room: manager.request_status[room]
 
         chunk = TransferKVChunk(
             room=3,
@@ -239,6 +321,125 @@ class TestPrefillBootstrapAdmission(unittest.TestCase):
 
         MooncakeKVManager._handle_decode_status(manager, 7, KVPoll.Success, 1)
         self.assertEqual(manager.request_status[7], KVPoll.Success)
+
+    def test_prefill_decode_status_failed_marks_bootstrap_failed(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.status_lock = threading.RLock()
+        manager.failure_lock = threading.Lock()
+        manager.request_status = {7: KVPoll.Bootstrapping}
+        manager.failure_records = {}
+        manager.transfer_infos = {7: {"session": object()}}
+        manager.req_to_decode_prefix_len = {7: 42}
+
+        MooncakeKVManager._handle_prefill_decode_status(
+            manager,
+            [
+                MooncakeKVManager.DECODE_STATUS_HEADER,
+                b"7",
+                str(KVPoll.Failed).encode("ascii"),
+                b"decode aborted before metadata",
+            ],
+        )
+
+        self.assertEqual(manager.request_status[7], KVPoll.Failed)
+        self.assertEqual(manager.failure_records[7], "decode aborted before metadata")
+        self.assertNotIn(7, manager.transfer_infos)
+        self.assertNotIn(7, manager.req_to_decode_prefix_len)
+
+    def _make_abort_receiver(self, status=KVPoll.Bootstrapping):
+        class FakeKVManager:
+            def __init__(self, status):
+                self.status = status
+                self.failures = []
+                self.statuses = []
+
+            def check_status(self, bootstrap_room):
+                if self.status is None:
+                    raise KeyError(bootstrap_room)
+                return self.status
+
+            def record_failure(self, bootstrap_room, reason):
+                self.failures.append((bootstrap_room, reason))
+
+            def update_status(self, bootstrap_room, status):
+                self.statuses.append((bootstrap_room, status))
+
+        class FakeLock:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, traceback):
+                return False
+
+        class FakeSocket:
+            def __init__(self):
+                self.messages = []
+
+            def send_multipart(self, msg):
+                self.messages.append(msg)
+
+        fake_socket = FakeSocket()
+        receiver = MooncakeKVReceiver.__new__(MooncakeKVReceiver)
+        receiver.bootstrap_room = 17
+        receiver.bootstrap_infos = [
+            {"rank_ip": "127.0.0.1", "rank_port": 12345},
+            {"rank_ip": "127.0.0.2", "rank_port": 12346},
+        ]
+        receiver.kv_mgr = FakeKVManager(status)
+        receiver.conclude_state = None
+        receiver._connect_to_bootstrap_server = lambda bootstrap_info: (
+            fake_socket,
+            FakeLock(),
+        )
+        return receiver, fake_socket
+
+    def test_mooncake_receiver_abort_notifies_prefill_status_before_metadata(self):
+        receiver, fake_socket = self._make_abort_receiver(KVPoll.Bootstrapping)
+        receiver.abort("decode aborted before metadata")
+
+        self.assertEqual(
+            receiver.kv_mgr.failures, [(17, "decode aborted before metadata")]
+        )
+        self.assertEqual(receiver.kv_mgr.statuses, [(17, KVPoll.Failed)])
+        self.assertEqual(receiver.conclude_state, KVPoll.Failed)
+        self.assertEqual(len(fake_socket.messages), 2)
+        self.assertTrue(
+            all(
+                msg[0] == MooncakeKVManager.DECODE_STATUS_HEADER
+                for msg in fake_socket.messages
+            )
+        )
+        self.assertTrue(all(msg[1] == b"17" for msg in fake_socket.messages))
+        self.assertTrue(
+            all(
+                msg[2] == str(KVPoll.Failed).encode("ascii")
+                for msg in fake_socket.messages
+            )
+        )
+        self.assertTrue(
+            all(
+                msg[3] == b"decode aborted before metadata"
+                for msg in fake_socket.messages
+            )
+        )
+
+    def test_mooncake_receiver_abort_does_not_notify_prefill_after_metadata(self):
+        receiver, fake_socket = self._make_abort_receiver(KVPoll.WaitingForInput)
+        receiver.abort("stream client disconnected")
+
+        self.assertEqual(receiver.kv_mgr.failures, [(17, "stream client disconnected")])
+        self.assertEqual(receiver.kv_mgr.statuses, [(17, KVPoll.Failed)])
+        self.assertEqual(receiver.conclude_state, KVPoll.Failed)
+        self.assertEqual(fake_socket.messages, [])
+
+    def test_mooncake_receiver_abort_does_not_resurrect_cleared_room(self):
+        receiver, fake_socket = self._make_abort_receiver(None)
+        receiver.abort("late abort after clear")
+
+        self.assertEqual(receiver.kv_mgr.failures, [])
+        self.assertEqual(receiver.kv_mgr.statuses, [])
+        self.assertEqual(receiver.conclude_state, KVPoll.Failed)
+        self.assertEqual(fake_socket.messages, [])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/disaggregation/test_prefill_bootstrap_admission.py
+++ b/test/registered/unit/disaggregation/test_prefill_bootstrap_admission.py
@@ -1,0 +1,245 @@
+import threading
+import time
+import types
+import unittest
+from collections import defaultdict, deque
+from types import SimpleNamespace
+
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.mooncake.conn import (
+    MooncakeKVManager,
+    MooncakeKVReceiver,
+    MooncakeKVSender,
+    TransferKVChunk,
+)
+from sglang.srt.disaggregation.prefill import PrefillBootstrapQueue
+from sglang.srt.disaggregation.utils import ReqToMetadataIdxAllocator
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+def _make_req(rid: str):
+    return SimpleNamespace(
+        rid=rid,
+        origin_input_ids=[1, 2, 3],
+        sampling_params=SimpleNamespace(max_new_tokens=8),
+        finished_reason=None,
+        return_logprob=False,
+        disagg_kv_sender=None,
+    )
+
+
+def _make_queue(capacity: int):
+    queue = PrefillBootstrapQueue.__new__(PrefillBootstrapQueue)
+    queue.queue = []
+    queue.pending_queue = deque()
+    queue.req_to_metadata_buffer_idx_allocator = ReqToMetadataIdxAllocator(capacity)
+    queue.max_total_num_tokens = 1024
+    queue.scheduler = SimpleNamespace(
+        waiting_queue=[],
+        disagg_prefill_inflight_queue=[],
+        cur_batch=None,
+        last_batch=None,
+        running_batch=SimpleNamespace(reqs=[]),
+        model_config=SimpleNamespace(num_key_value_heads=1),
+    )
+
+    def fake_create_kv_sender(self, req, num_kv_heads):
+        req.disagg_kv_sender = object()
+        self.queue.append(req)
+
+    queue._create_kv_sender = types.MethodType(fake_create_kv_sender, queue)
+    return queue
+
+
+class TestPrefillBootstrapAdmission(unittest.TestCase):
+    def test_admission_defers_requests_without_sender(self):
+        queue = _make_queue(capacity=2)
+        reqs = [_make_req(f"req-{i}") for i in range(3)]
+
+        for req in reqs:
+            queue.add(req, num_kv_heads=1)
+
+        self.assertEqual([req.rid for req in queue.queue], ["req-0", "req-1"])
+        self.assertEqual([req.rid for req in queue.pending_queue], ["req-2"])
+        self.assertIsNotNone(reqs[0].disagg_kv_sender)
+        self.assertIsNotNone(reqs[1].disagg_kv_sender)
+        self.assertIsNone(reqs[2].disagg_kv_sender)
+
+    def test_pending_request_admits_when_active_sender_finishes(self):
+        queue = _make_queue(capacity=2)
+        reqs = [_make_req(f"req-{i}") for i in range(3)]
+        for req in reqs:
+            queue.add(req, num_kv_heads=1)
+
+        queue.queue.pop(0)
+        queue._admit_pending(num_kv_heads=1)
+
+        self.assertEqual([req.rid for req in queue.queue], ["req-1", "req-2"])
+        self.assertEqual(list(queue.pending_queue), [])
+        self.assertIsNotNone(reqs[2].disagg_kv_sender)
+
+    def test_waiting_and_inflight_reqs_count_against_admission(self):
+        queue = _make_queue(capacity=2)
+        active_waiting = _make_req("waiting")
+        active_waiting.disagg_kv_sender = object()
+        queue.scheduler.waiting_queue = [active_waiting]
+
+        queue.add(_make_req("req-0"), num_kv_heads=1)
+        queue.add(_make_req("req-1"), num_kv_heads=1)
+
+        self.assertEqual([req.rid for req in queue.queue], ["req-0"])
+        self.assertEqual([req.rid for req in queue.pending_queue], ["req-1"])
+
+    def test_running_batch_reqs_count_against_admission(self):
+        queue = _make_queue(capacity=2)
+        active_running = _make_req("running")
+        active_running.disagg_kv_sender = object()
+        queue.scheduler.running_batch = SimpleNamespace(reqs=[active_running])
+
+        queue.add(_make_req("req-0"), num_kv_heads=1)
+        queue.add(_make_req("req-1"), num_kv_heads=1)
+
+        self.assertEqual([req.rid for req in queue.queue], ["req-0"])
+        self.assertEqual([req.rid for req in queue.pending_queue], ["req-1"])
+
+    def test_mooncake_sender_bootstrap_timeout_starts_after_metadata_arrives(self):
+        class FakeKVManager:
+            bootstrap_timeout = 60.0
+            transfer_infos = {}
+
+            def check_status(self, bootstrap_room):
+                return KVPoll.Bootstrapping
+
+        sender = MooncakeKVSender.__new__(MooncakeKVSender)
+        sender.conclude_state = None
+        sender.kv_mgr = FakeKVManager()
+        sender.bootstrap_room = 7
+        sender.init_time = None
+
+        self.assertEqual(sender.poll(), KVPoll.Bootstrapping)
+        self.assertIsNone(sender.init_time)
+
+        sender.kv_mgr.transfer_infos[sender.bootstrap_room] = {"session": object()}
+        before_poll = time.time()
+
+        self.assertEqual(sender.poll(), KVPoll.Bootstrapping)
+        self.assertIsNotNone(sender.init_time)
+        self.assertGreaterEqual(sender.init_time, before_poll)
+
+    def test_mooncake_receiver_waiting_timeout_starts_after_transfer_begins(self):
+        class FakeKVManager:
+            waiting_timeout = 60.0
+
+            def __init__(self):
+                self.status = KVPoll.WaitingForInput
+                self.failures = []
+
+            def check_status(self, bootstrap_room):
+                return self.status
+
+            def record_failure(self, bootstrap_room, reason):
+                self.failures.append((bootstrap_room, reason))
+
+        receiver = MooncakeKVReceiver.__new__(MooncakeKVReceiver)
+        receiver.conclude_state = None
+        receiver.kv_mgr = FakeKVManager()
+        receiver.bootstrap_room = 11
+        receiver.init_time = None
+
+        self.assertEqual(receiver.poll(), KVPoll.WaitingForInput)
+        self.assertIsNone(receiver.init_time)
+        self.assertEqual(receiver.kv_mgr.failures, [])
+
+        receiver.kv_mgr.status = KVPoll.Transferring
+        before_poll = time.time()
+
+        self.assertEqual(receiver.poll(), KVPoll.Transferring)
+        self.assertIsNotNone(receiver.init_time)
+        self.assertGreaterEqual(receiver.init_time, before_poll)
+
+        receiver.init_time = time.time() - receiver.kv_mgr.waiting_timeout - 1
+
+        self.assertEqual(receiver.poll(), KVPoll.Failed)
+        self.assertIn("KVPoll.Transferring", receiver.kv_mgr.failures[0][1])
+
+    def test_mooncake_transfer_worker_drops_failed_room_without_transfer(self):
+        class StopLoop(BaseException):
+            pass
+
+        class OneChunkQueue:
+            def __init__(self, chunk):
+                self.chunk = chunk
+                self.calls = 0
+
+            def get(self):
+                self.calls += 1
+                if self.calls == 1:
+                    return self.chunk
+                raise StopLoop()
+
+        manager = SimpleNamespace()
+        manager.enable_staging = False
+        manager.transfer_infos = {3: {"session": object()}}
+        manager.req_to_decode_prefix_len = {3: 0}
+        manager.request_status = {3: KVPoll.Failed}
+
+        chunk = TransferKVChunk(
+            room=3,
+            prefill_kv_indices=[],
+            index_slice=slice(0, 0),
+            is_last_chunk=True,
+            prefill_aux_index=0,
+            state_indices=None,
+        )
+
+        with self.assertRaises(StopLoop):
+            MooncakeKVManager.transfer_worker(manager, OneChunkQueue(chunk), None)
+
+        self.assertEqual(manager.transfer_infos, {})
+        self.assertEqual(manager.req_to_decode_prefix_len, {})
+
+    def test_decode_status_success_ignores_cleared_room(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.status_lock = threading.RLock()
+        manager.request_status = {}
+        manager.required_prefill_response_num_table = {7: 1}
+        manager.prefill_response_tracker = defaultdict(set)
+        manager.enable_staging = False
+
+        MooncakeKVManager._handle_decode_status(manager, 7, KVPoll.Success, 0)
+
+        self.assertNotIn(7, manager.request_status)
+        self.assertNotIn(7, manager.prefill_response_tracker)
+
+    def test_decode_status_success_ignores_missing_response_count(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.status_lock = threading.RLock()
+        manager.request_status = {7: KVPoll.Transferring}
+        manager.required_prefill_response_num_table = {}
+        manager.prefill_response_tracker = defaultdict(set)
+        manager.enable_staging = False
+
+        MooncakeKVManager._handle_decode_status(manager, 7, KVPoll.Success, 0)
+
+        self.assertEqual(manager.request_status[7], KVPoll.Transferring)
+        self.assertNotIn(7, manager.prefill_response_tracker)
+
+    def test_decode_status_success_completes_after_required_responses(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.status_lock = threading.RLock()
+        manager.request_status = {7: KVPoll.Transferring}
+        manager.required_prefill_response_num_table = {7: 2}
+        manager.prefill_response_tracker = defaultdict(set)
+        manager.enable_staging = False
+
+        MooncakeKVManager._handle_decode_status(manager, 7, KVPoll.Success, 0)
+        self.assertEqual(manager.request_status[7], KVPoll.Transferring)
+
+        MooncakeKVManager._handle_decode_status(manager, 7, KVPoll.Success, 1)
+        self.assertEqual(manager.request_status[7], KVPoll.Success)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -62,6 +62,27 @@ def _make_req(rid="test-req-0", origin_input_ids=None, output_ids=None):
     return req
 
 
+def test_next_decode_host_budget_counts_only_new_allocations():
+    from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+
+    coordinator = HiSparseCoordinator.__new__(HiSparseCoordinator)
+    coordinator.compress_ratio = 1
+    coordinator._skip_first_backup = [False]
+    coordinator._pending_draft_extend_backup = (
+        torch.arange(8, dtype=torch.int64),
+        torch.arange(8, dtype=torch.int64),
+        torch.arange(8, dtype=torch.int64),
+    )
+    req = _make_req("host-budget", list(range(4)))
+    req.req_pool_idx = 0
+    req.kv_committed_len = 4
+
+    assert (
+        coordinator.host_tokens_required_next_decode([req], speculative_token_budget=3)
+        == 4
+    )
+
+
 class TestHiSparseUnit(unittest.TestCase):
     """Test class that builds a minimal HiSparse component stack."""
 

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -171,6 +171,7 @@ class TestHiSparseUnit(unittest.TestCase):
         self.coordinator.lru_slots[:] = self.coordinator._lru_init.view(1, 1, -1)
         self.coordinator.ack_staging_queue.clear()
         self.coordinator._has_pending_backup = False
+        self.coordinator._pending_draft_extend_backup = None
         for i in range(len(self.coordinator._skip_first_backup)):
             self.coordinator._skip_first_backup[i] = False
 
@@ -427,6 +428,62 @@ class TestHiSparseUnit(unittest.TestCase):
 
         self._cleanup_req(req, kv_loc, logical_only=True)
         self._assert_sizes_restored(initial, "long_seq")
+
+    def test_map_last_loc_records_newest_token_for_multistep_swap(self):
+        """Multi-step verify can resolve the newest-token extra-page slot."""
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE + self.page_size
+        req = _make_req("newest-token-metadata", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len)
+        self.coordinator.alloc_device_buffer(req)
+
+        req_idx = req.req_pool_idx
+        req_pool_indices = torch.tensor([req_idx], dtype=torch.int64, device="cuda")
+        seq_lens = torch.tensor([fill_len], dtype=torch.int64, device="cuda")
+        seq_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
+
+        self.coordinator.map_last_loc_to_buffer(
+            seq_lens=seq_lens,
+            out_cache_loc=kv_loc[-1:],
+            req_pool_indices=req_pool_indices,
+            seq_lens_cpu=seq_lens_cpu,
+        )
+
+        newest_slot = self.coordinator.req_to_device_buffer[req_idx, DEVICE_BUFFER_SIZE]
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, DEVICE_BUFFER_SIZE
+                ]
+                == fill_len - 1
+            )
+        )
+        self.assertEqual(
+            int(
+                self.allocator.full_to_hisparse_device_index_mapping[kv_loc[-1]].item()
+            ),
+            int(newest_slot.item()),
+        )
+
+        topk = torch.full((1, 4, TOP_K), -1, dtype=torch.int32, device="cuda")
+        topk[0, 0, 0] = fill_len - 1
+        self.coordinator.num_real_reqs[0] = 1
+        locs = self.coordinator.swap_in_selected_pages(
+            req_pool_indices=req_pool_indices,
+            compressed_seq_lens=torch.full(
+                (4,), fill_len, dtype=torch.int32, device="cuda"
+            ),
+            top_k_result=topk,
+            layer_id=0,
+            token_position_space="full",
+            num_steps=4,
+        )
+        self.assertEqual(int(locs[0, 0, 0].item()), int(newest_slot.item()))
+
+        self._cleanup_req(req, kv_loc)
+        self._assert_sizes_restored(initial, "newest_token_metadata")
 
     # ==================================================================
     # Test: Kernel LRU replacement across multiple decode steps
@@ -757,6 +814,364 @@ class TestHiSparseUnit(unittest.TestCase):
             self._cleanup_req(req, kv_locs[i], logical_only=is_long)
 
         self._assert_sizes_restored(initial, "batch_multiple")
+
+    # ==================================================================
+    # Test: HiSparse MTP draft slots
+    # ==================================================================
+    def test_draft_slots_use_extra_page_after_newest_slot(self):
+        """Uniform draft slots start after the newest-token slot."""
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE
+        draft_num = 3
+        req = _make_req("draft-slots-uniform", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len)
+        self.coordinator.alloc_device_buffer(req)
+
+        req_idx = req.req_pool_idx
+        extra_start = DEVICE_BUFFER_SIZE + 1
+        req_pool_indices = torch.tensor([req_idx], dtype=torch.int64, device="cuda")
+        start_positions_cpu = torch.tensor([DEVICE_BUFFER_SIZE], dtype=torch.int64)
+
+        hot_tokens_before = self.coordinator.req_device_buffer_tokens[
+            :, req_idx, :DEVICE_BUFFER_SIZE
+        ].clone()
+        newest_token_sentinel = torch.full(
+            (LAYER_NUM,), 777, dtype=torch.int32, device="cuda"
+        )
+        self.coordinator.req_device_buffer_tokens[:, req_idx, DEVICE_BUFFER_SIZE] = (
+            newest_token_sentinel
+        )
+
+        device_slots = self.coordinator.get_draft_device_slots(
+            req_pool_indices,
+            draft_num,
+            start_positions_cpu,
+        )
+
+        expected_slots = self.coordinator.req_to_device_buffer[
+            req_idx, extra_start : extra_start + draft_num
+        ]
+        expected_token_positions = torch.arange(
+            DEVICE_BUFFER_SIZE,
+            DEVICE_BUFFER_SIZE + draft_num,
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+        self.assertTrue(torch.equal(device_slots, expected_slots))
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, :DEVICE_BUFFER_SIZE
+                ],
+                hot_tokens_before,
+            ),
+            "Draft slots must not rewrite hot-buffer token metadata",
+        )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, DEVICE_BUFFER_SIZE
+                ],
+                newest_token_sentinel,
+            ),
+            "Draft slots must not overwrite the newest-token slot",
+        )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, extra_start : extra_start + draft_num
+                ],
+                expected_token_positions.unsqueeze(0).expand(LAYER_NUM, -1),
+            )
+        )
+
+        self._cleanup_req(req, kv_loc)
+        self._assert_sizes_restored(initial, "draft_slots_uniform")
+
+    def test_draft_slots_variable_respect_per_request_counts(self):
+        """Variable draft slots only populate each request's actual token count."""
+        initial = self._get_initial_sizes()
+        reqs = [
+            _make_req("draft-slots-variable-0"),
+            _make_req("draft-slots-variable-1"),
+        ]
+        for req in reqs:
+            self._alloc_req_slot(req)
+
+        req_pool_indices = torch.tensor(
+            [req.req_pool_idx for req in reqs], dtype=torch.int64, device="cuda"
+        )
+        tokens_per_req_cpu = torch.tensor([1, 3], dtype=torch.int64)
+        start_positions_cpu = torch.tensor(
+            [DEVICE_BUFFER_SIZE, DEVICE_BUFFER_SIZE], dtype=torch.int64
+        )
+        extra_start = DEVICE_BUFFER_SIZE + 1
+
+        device_slots = self.coordinator.get_draft_device_slots_variable(
+            req_pool_indices,
+            tokens_per_req_cpu,
+            start_positions_cpu,
+        )
+
+        expected_slots = torch.cat(
+            [
+                self.coordinator.req_to_device_buffer[
+                    reqs[0].req_pool_idx, extra_start : extra_start + 1
+                ],
+                self.coordinator.req_to_device_buffer[
+                    reqs[1].req_pool_idx, extra_start : extra_start + 3
+                ],
+            ]
+        )
+        self.assertTrue(torch.equal(device_slots, expected_slots))
+
+        req0_expected = torch.tensor(
+            [DEVICE_BUFFER_SIZE, -1, -1], dtype=torch.int32, device="cuda"
+        )
+        req1_expected = torch.arange(
+            DEVICE_BUFFER_SIZE,
+            DEVICE_BUFFER_SIZE + 3,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, reqs[0].req_pool_idx, extra_start : extra_start + 3
+                ],
+                req0_expected.unsqueeze(0).expand(LAYER_NUM, -1),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, reqs[1].req_pool_idx, extra_start : extra_start + 3
+                ],
+                req1_expected.unsqueeze(0).expand(LAYER_NUM, -1),
+            )
+        )
+
+        for req in reqs:
+            self.coordinator.request_finished(req)
+            self._free_req_slot(req)
+        self._assert_sizes_restored(initial, "draft_slots_variable")
+
+    def test_finalize_accepted_tokens_remaps_newest_and_clears_rejected(self):
+        """Accepted MTP tokens move the last accepted KV to newest slot."""
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE
+        draft_num = 4
+        req = _make_req("finalize-accepted", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len)
+        self.coordinator.alloc_device_buffer(req)
+
+        req_idx = req.req_pool_idx
+        req_pool_indices = torch.tensor([req_idx], dtype=torch.int64, device="cuda")
+        start_positions_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        draft_device_slots = self.coordinator.get_draft_device_slots(
+            req_pool_indices,
+            draft_num,
+            start_positions_cpu,
+        )
+
+        device = self.allocator.device
+        prefix_lens = torch.tensor([fill_len], dtype=torch.int64, device=device)
+        prefix_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        seq_lens = torch.tensor(
+            [fill_len + draft_num], dtype=torch.int64, device=device
+        )
+        seq_lens_cpu = torch.tensor([fill_len + draft_num], dtype=torch.int64)
+        last_loc = kv_loc[-1:].to(device=device)
+        draft_cache_locs = self.allocator.alloc_extend_with_device_mapping(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            draft_num,
+            draft_device_slots,
+        )
+        self.req_to_token_pool.write(
+            (req_idx, slice(fill_len, fill_len + draft_num)), draft_cache_locs
+        )
+        req.kv_allocated_len = fill_len + draft_num
+        req.kv_committed_len = fill_len + draft_num
+
+        for lid in range(LAYER_NUM):
+            for i in range(draft_num):
+                self.device_pool.kv_buffer[lid][draft_device_slots[i]] = (
+                    self._kv_pattern(lid, fill_len + i)
+                )
+
+        accepted_cache_locs = draft_cache_locs[:2]
+        accepted_token_positions = torch.tensor(
+            [fill_len, fill_len + 1], dtype=torch.int64, device="cuda"
+        )
+        self.coordinator.finalize_accepted_tokens(
+            req_pool_indices=req_pool_indices,
+            accepted_cache_locs=accepted_cache_locs,
+            draft_cache_locs=draft_cache_locs,
+            num_correct_drafts=torch.tensor([1], dtype=torch.int64, device="cuda"),
+            num_correct_drafts_cpu=torch.tensor([1], dtype=torch.int64),
+            accepted_token_positions=accepted_token_positions,
+        )
+
+        mapping = self.allocator.full_to_hisparse_device_index_mapping
+        newest_slot = self.coordinator.req_to_device_buffer[req_idx, DEVICE_BUFFER_SIZE]
+
+        self.assertEqual(
+            int(mapping[accepted_cache_locs[0]].item()),
+            int(draft_device_slots[0].item()),
+        )
+        self.assertEqual(int(mapping[accepted_cache_locs[-1]].item()), int(newest_slot))
+        self.assertTrue(torch.all(mapping[draft_cache_locs[2:]] == 0))
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, DEVICE_BUFFER_SIZE
+                ]
+                == fill_len + 1
+            )
+        )
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_to_host_pool[req_idx, accepted_token_positions]
+                >= 0
+            )
+        )
+        for lid in range(LAYER_NUM):
+            expected = self._kv_pattern(lid, fill_len + 1)
+            actual = self.device_pool.kv_buffer[lid][newest_slot.long()]
+            self.assertTrue(
+                torch.allclose(
+                    actual.float(),
+                    torch.full_like(actual.float(), expected),
+                    atol=1e-2,
+                ),
+                f"Layer {lid}: newest slot was not updated from last accepted token",
+            )
+
+        self.coordinator.finish_pending_draft_extend_backup()
+        self.assertEqual(int(mapping[accepted_cache_locs[0]].item()), 0)
+        self.assertEqual(int(mapping[accepted_cache_locs[-1]].item()), int(newest_slot))
+
+        self.coordinator.request_finished(req)
+        self.allocator.free(torch.cat([kv_loc, draft_cache_locs]))
+        self._free_req_slot(req)
+        self._assert_sizes_restored(initial, "finalize_accepted_tokens")
+
+    def test_finalize_accepted_tokens_keeps_short_last_token_in_hot_slot(self):
+        """Short-context accepted tokens use the hot slot read by the fast path."""
+        initial = self._get_initial_sizes()
+        fill_len = self.page_size
+        draft_num = 4
+        req = _make_req("finalize-accepted-short", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len)
+        self.coordinator.alloc_device_buffer(req)
+
+        req_idx = req.req_pool_idx
+        req_pool_indices = torch.tensor([req_idx], dtype=torch.int64, device="cuda")
+        start_positions_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        draft_device_slots = self.coordinator.get_draft_device_slots(
+            req_pool_indices,
+            draft_num,
+            start_positions_cpu,
+        )
+
+        device = self.allocator.device
+        prefix_lens = torch.tensor([fill_len], dtype=torch.int64, device=device)
+        prefix_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        seq_lens = torch.tensor(
+            [fill_len + draft_num], dtype=torch.int64, device=device
+        )
+        seq_lens_cpu = torch.tensor([fill_len + draft_num], dtype=torch.int64)
+        last_loc = kv_loc[-1:].to(device=device)
+        draft_cache_locs = self.allocator.alloc_extend_with_device_mapping(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            draft_num,
+            draft_device_slots,
+        )
+        self.req_to_token_pool.write(
+            (req_idx, slice(fill_len, fill_len + draft_num)), draft_cache_locs
+        )
+        req.kv_allocated_len = fill_len + draft_num
+        req.kv_committed_len = fill_len + draft_num
+
+        accepted_cache_locs = draft_cache_locs[:2]
+        accepted_token_positions = torch.tensor(
+            [fill_len, fill_len + 1], dtype=torch.int64, device="cuda"
+        )
+        self.coordinator.finalize_accepted_tokens(
+            req_pool_indices=req_pool_indices,
+            accepted_cache_locs=accepted_cache_locs,
+            draft_cache_locs=draft_cache_locs,
+            num_correct_drafts=torch.tensor([1], dtype=torch.int64, device="cuda"),
+            num_correct_drafts_cpu=torch.tensor([1], dtype=torch.int64),
+            accepted_token_positions=accepted_token_positions,
+        )
+
+        mapping = self.allocator.full_to_hisparse_device_index_mapping
+        last_hot_slot = self.coordinator.req_to_device_buffer[req_idx, fill_len + 1]
+        extra_newest_slot = self.coordinator.req_to_device_buffer[
+            req_idx, DEVICE_BUFFER_SIZE
+        ]
+
+        self.assertEqual(
+            int(mapping[accepted_cache_locs[-1]].item()), int(last_hot_slot.item())
+        )
+        self.assertNotEqual(int(last_hot_slot.item()), int(extra_newest_slot.item()))
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_device_buffer_tokens[:, req_idx, fill_len + 1]
+                == fill_len + 1
+            )
+        )
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_device_buffer_token_locs[:, req_idx, fill_len + 1]
+                == last_hot_slot.to(torch.int32)
+            )
+        )
+        self.assertIsNone(self.coordinator._pending_draft_extend_backup)
+
+        self.coordinator.request_finished(req)
+        self.allocator.free(torch.cat([kv_loc, draft_cache_locs]))
+        self._free_req_slot(req)
+        self._assert_sizes_restored(initial, "finalize_accepted_tokens_short")
+
+    def test_draft_extend_cuda_graph_disabled_for_hisparse(self):
+        """Draft-extend graph replay is skipped when HiSparse owns KV mapping."""
+        from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
+            EAGLEDraftExtendCudaGraphRunner,
+        )
+
+        runner = EAGLEDraftExtendCudaGraphRunner.__new__(
+            EAGLEDraftExtendCudaGraphRunner
+        )
+        runner.eagle_worker = SimpleNamespace(
+            target_worker=SimpleNamespace(
+                model_runner=SimpleNamespace(hisparse_coordinator=object())
+            )
+        )
+        forward_batch = SimpleNamespace(
+            token_to_kv_pool=SimpleNamespace(
+                translate_loc_to_hisparse_device=lambda loc: loc
+            )
+        )
+
+        self.assertTrue(runner._uses_target_hisparse_coordinator(forward_batch))
+        self.assertFalse(runner.can_run(forward_batch))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -102,7 +102,6 @@ def test_schedule_batch_hisparse_spec_v2_host_budget_uses_current_alloc_helper(
     )
 
     batch = ScheduleBatch.__new__(ScheduleBatch)
-    batch.is_spec_v2 = True
     batch.spec_algorithm = SimpleNamespace(is_none=lambda: False)
     batch.hisparse_coordinator = SimpleNamespace(
         supports_hisparse_draft_slots=lambda: True

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -497,6 +497,7 @@ class TestHiSparseUnit(unittest.TestCase):
             out_cache_loc=kv_loc[-1:],
             req_pool_indices=req_pool_indices,
             seq_lens_cpu=seq_lens_cpu,
+            req_pool_indices_cpu=torch.tensor([req_idx], dtype=torch.int64),
         )
 
         newest_slot = self.coordinator.req_to_device_buffer[req_idx, DEVICE_BUFFER_SIZE]
@@ -895,9 +896,9 @@ class TestHiSparseUnit(unittest.TestCase):
         ].clone()
         self.coordinator.mem_pool_host.free(old_host_index)
         self.coordinator.req_to_host_pool[req.req_pool_idx, missing_pos] = -1
-        filler = self.coordinator.mem_pool_host.alloc(
-            self.coordinator.mem_pool_host.available_size()
-        )
+        available = self.coordinator.mem_pool_host.available_size()
+        filler_size = available - available % self.coordinator.mem_pool_host.page_size
+        filler = self.coordinator.mem_pool_host.alloc(filler_size)
         self.assertIsNotNone(filler, "Host filler alloc failed")
 
         newest_slot = self.coordinator.req_to_device_buffer[

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -83,6 +83,34 @@ def test_next_decode_host_budget_counts_only_new_allocations():
     )
 
 
+def test_schedule_batch_hisparse_spec_v2_host_budget_uses_current_alloc_helper(
+    monkeypatch,
+):
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
+    from sglang.srt.mem_cache import common as mem_cache_common
+
+    monkeypatch.setattr(
+        mem_cache_common,
+        "get_global_server_args",
+        lambda: SimpleNamespace(
+            speculative_algorithm="EAGLE",
+            speculative_num_steps=3,
+            speculative_eagle_topk=1,
+            max_speculative_num_draft_tokens=4,
+            page_size=64,
+        ),
+    )
+
+    batch = ScheduleBatch.__new__(ScheduleBatch)
+    batch.is_spec_v2 = True
+    batch.spec_algorithm = SimpleNamespace(is_none=lambda: False)
+    batch.hisparse_coordinator = SimpleNamespace(
+        supports_hisparse_draft_slots=lambda: True
+    )
+
+    assert batch._host_tokens_required_next_decode_spec([object(), object()]) == 10
+
+
 class TestHiSparseUnit(unittest.TestCase):
     """Test class that builds a minimal HiSparse component stack."""
 

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -703,6 +703,174 @@ class TestHiSparseUnit(unittest.TestCase):
         self._cleanup_req(req, kv_loc, logical_only=True)
         self._assert_sizes_restored(initial, "direct_path")
 
+    def test_retract_preserves_host_indices_and_resume_reuses_them(self):
+        """Retracted PD decode requests keep host KV and rebuild device state."""
+        from sglang.srt.disaggregation.decode import DecodePreallocQueue
+
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE + self.page_size
+        req = _make_req("retract-resume-req", list(range(fill_len)))
+        req.set_extend_input_len = lambda value: setattr(req, "extend_input_len", value)
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len, logical_only=True)
+        self._populate_host_pool(req, fill_len)
+        self.coordinator.admit_request_direct(req)
+
+        missing_pos = fill_len - 1
+        host_indices = self.coordinator.req_to_host_pool[
+            req.req_pool_idx, :fill_len
+        ].clone()
+        old_host_index = host_indices[missing_pos : missing_pos + 1]
+        self.coordinator.mem_pool_host.free(old_host_index)
+        self.coordinator.req_to_host_pool[req.req_pool_idx, missing_pos] = -1
+        newest_slot = self.coordinator.req_to_device_buffer[
+            req.req_pool_idx, DEVICE_BUFFER_SIZE
+        ]
+        self.allocator.full_to_hisparse_device_index_mapping[kv_loc[missing_pos]] = (
+            newest_slot
+        )
+        for lid in range(LAYER_NUM):
+            self.device_pool.kv_buffer[lid][newest_slot] = self._kv_pattern(
+                lid, missing_pos
+            )
+        host_available_after_admit = self.coordinator.mem_pool_host.available_size()
+
+        self.assertTrue(self.coordinator.retract_req(req))
+        self.assertTrue(hasattr(req, "hisparse_retracted_host_indices"))
+        self.assertEqual(
+            self.coordinator.mem_pool_host.available_size(),
+            host_available_after_admit - 1,
+        )
+        self.assertTrue(
+            torch.all(self.coordinator.req_to_host_pool[req.req_pool_idx] < 0)
+        )
+        self.assertEqual(
+            self.allocator.hisparse_attn_allocator.available_size(), initial[1]
+        )
+
+        self.allocator.logical_attn_allocator.free(kv_loc)
+        self._free_req_slot(req)
+        req.kv_allocated_len = 0
+        req.kv_committed_len = 0
+
+        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+        queue.req_to_token_pool = self.req_to_token_pool
+        queue.token_to_kv_pool_allocator = self.allocator
+        queue.num_reserved_decode_tokens = 1
+        queue.tree_cache = SimpleNamespace(
+            evictable_size=lambda: 0,
+            protected_size=lambda: 0,
+        )
+        queue.scheduler = SimpleNamespace(
+            enable_hisparse=True,
+            hisparse_coordinator=self.coordinator,
+            server_args=SimpleNamespace(
+                disaggregation_decode_enable_radix_cache=False,
+            ),
+        )
+
+        reused_host_indices = queue._pre_alloc(req)
+        self.assertFalse(hasattr(req, "hisparse_retracted_host_indices"))
+        self.assertTrue(
+            torch.equal(
+                reused_host_indices[:missing_pos].cpu(),
+                host_indices[:missing_pos].cpu(),
+            )
+        )
+        self.assertTrue(torch.all(reused_host_indices >= 0))
+        for lid in range(LAYER_NUM):
+            actual = self.coordinator.mem_pool_host.kv_buffer[lid][
+                reused_host_indices[missing_pos]
+            ]
+            expected = self._kv_pattern(lid, missing_pos)
+            self.assertTrue(
+                torch.allclose(
+                    actual.float(),
+                    torch.full_like(actual.float(), expected),
+                    atol=1e-2,
+                )
+            )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_to_host_pool[req.req_pool_idx, :fill_len].cpu(),
+                reused_host_indices.cpu(),
+            )
+        )
+        self.assertEqual(
+            self.coordinator.mem_pool_host.available_size(),
+            host_available_after_admit - 1,
+        )
+
+        self.coordinator.admit_request_direct(req)
+        resumed_kv_loc = self.req_to_token_pool.req_to_token[
+            req.req_pool_idx, :fill_len
+        ].clone()
+        self.coordinator.request_finished(req)
+        self.allocator.logical_attn_allocator.free(resumed_kv_loc)
+        self._free_req_slot(req)
+        self._assert_sizes_restored(initial, "retract_resume")
+
+    def test_release_retracted_req_frees_preserved_host_indices(self):
+        """Abort on the retracted queue releases preserved host KV."""
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE + self.page_size
+        req = _make_req("retract-abort-req", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len, logical_only=True)
+        self._populate_host_pool(req, fill_len)
+        self.coordinator.admit_request_direct(req)
+
+        self.assertTrue(self.coordinator.retract_req(req))
+        self.allocator.logical_attn_allocator.free(kv_loc)
+        self._free_req_slot(req)
+
+        self.coordinator.release_retracted_req(req)
+        self.assertFalse(hasattr(req, "hisparse_retracted_host_indices"))
+        self._assert_sizes_restored(initial, "retract_abort")
+
+    def test_retract_reports_failure_when_backup_host_alloc_fails(self):
+        """A failed retract backup is reported so the scheduler can abort one req."""
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE + self.page_size
+        req = _make_req("retract-backup-full-req", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len, logical_only=True)
+        self._populate_host_pool(req, fill_len)
+        self.coordinator.admit_request_direct(req)
+
+        missing_pos = fill_len - 1
+        old_host_index = self.coordinator.req_to_host_pool[
+            req.req_pool_idx, missing_pos : missing_pos + 1
+        ].clone()
+        self.coordinator.mem_pool_host.free(old_host_index)
+        self.coordinator.req_to_host_pool[req.req_pool_idx, missing_pos] = -1
+        filler = self.coordinator.mem_pool_host.alloc(
+            self.coordinator.mem_pool_host.available_size()
+        )
+        self.assertIsNotNone(filler, "Host filler alloc failed")
+
+        newest_slot = self.coordinator.req_to_device_buffer[
+            req.req_pool_idx, DEVICE_BUFFER_SIZE
+        ]
+        self.allocator.full_to_hisparse_device_index_mapping[kv_loc[missing_pos]] = (
+            newest_slot
+        )
+
+        self.assertFalse(self.coordinator.retract_req(req))
+        self.assertFalse(hasattr(req, "hisparse_retracted_host_indices"))
+        self.assertFalse(
+            torch.all(self.coordinator.req_to_host_pool[req.req_pool_idx] < 0)
+        )
+
+        self.coordinator.request_finished(req)
+        self.allocator.logical_attn_allocator.free(kv_loc)
+        self._free_req_slot(req)
+        self.coordinator.mem_pool_host.free(filler)
+        self._assert_sizes_restored(initial, "retract_backup_full")
+
     # ==================================================================
     # Test: PD decode prealloc host page allocation
     # ==================================================================
@@ -958,6 +1126,66 @@ class TestHiSparseUnit(unittest.TestCase):
             self.coordinator.request_finished(req)
             self._free_req_slot(req)
         self._assert_sizes_restored(initial, "draft_slots_variable")
+
+    def test_draft_logical_alloc_allows_in_page_extend_with_no_free_pages(self):
+        """Draft logical allocation can extend inside an existing page at 0 free pages."""
+        if self.page_size == 1:
+            self.skipTest("In-page paged extension requires page_size > 1.")
+
+        initial = self._get_initial_sizes()
+        device = self.allocator.device
+        fill_len = self.page_size * 2 + 1
+        draft_num = 4
+
+        kv_loc = self.allocator.alloc_extend(
+            prefix_lens=torch.tensor([0], dtype=torch.int64, device=device),
+            prefix_lens_cpu=torch.tensor([0], dtype=torch.int64),
+            seq_lens=torch.tensor([fill_len], dtype=torch.int64, device=device),
+            seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
+            last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
+            extend_num_tokens=fill_len,
+        )
+        self.assertIsNotNone(kv_loc)
+
+        filler = self.allocator.logical_attn_allocator.alloc(
+            self.allocator.logical_attn_allocator.available_size()
+        )
+        self.assertIsNotNone(filler)
+        self.assertEqual(self.allocator.logical_attn_allocator.available_size(), 0)
+
+        prefix_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        seq_lens_cpu = torch.tensor([fill_len + draft_num], dtype=torch.int64)
+        device_slots = torch.arange(1, draft_num + 1, dtype=torch.int64, device=device)
+
+        draft_cache_locs = self.allocator.alloc_extend_with_device_mapping(
+            prefix_lens=prefix_lens_cpu.to(device=device),
+            prefix_lens_cpu=prefix_lens_cpu,
+            seq_lens=seq_lens_cpu.to(device=device),
+            seq_lens_cpu=seq_lens_cpu,
+            last_loc=kv_loc[-1:],
+            extend_num_tokens=draft_num,
+            device_slots=device_slots,
+        )
+
+        self.assertEqual(len(draft_cache_locs), draft_num)
+        self.assertEqual(self.allocator.logical_attn_allocator.available_size(), 0)
+        self.assertTrue(
+            torch.equal(
+                draft_cache_locs,
+                kv_loc[-1] + torch.arange(1, draft_num + 1, device=device),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                self.allocator.full_to_hisparse_device_index_mapping[draft_cache_locs],
+                device_slots,
+            )
+        )
+
+        self.allocator.full_to_hisparse_device_index_mapping[draft_cache_locs] = 0
+        self.allocator.free(torch.cat([kv_loc, draft_cache_locs]))
+        self.allocator.logical_attn_allocator.free(filler)
+        self._assert_sizes_restored(initial, "draft_logical_in_page_extend")
 
     def test_finalize_accepted_tokens_remaps_newest_and_clears_rejected(self):
         """Accepted MTP tokens move the last accepted KV to newest slot."""

--- a/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
+++ b/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
@@ -187,6 +187,57 @@ class TestDecodePreallocQueuePriority(unittest.TestCase):
         )
         self.assertEqual(failed, [])
 
+    def test_hisparse_host_budget_blocks_prealloc_before_host_alloc(self):
+        decode_req = self._new_decode_req("blocked", 1)
+        queue = self._new_queue([decode_req])
+        queue.num_reserved_decode_tokens = 2
+        queue.scheduler.enable_hisparse = True
+        queue.scheduler.hisparse_coordinator = SimpleNamespace(
+            padded_buffer_size=1,
+            compressed_host_len=lambda full_len: full_len,
+            host_decode_reserve_len=lambda full_len, num_decode_tokens: num_decode_tokens,
+            mem_pool_host=SimpleNamespace(available_size=MagicMock(return_value=4)),
+        )
+        queue.token_to_kv_pool_allocator.logical_attn_allocator.available_size.return_value = (
+            100
+        )
+        queue.token_to_kv_pool_allocator.hisparse_attn_allocator.available_size.return_value = (
+            100
+        )
+
+        preallocated, failed = queue.pop_preallocated()
+
+        self.assertEqual(preallocated, [])
+        self.assertEqual(failed, [])
+        queue._pre_alloc.assert_not_called()
+
+    def test_hisparse_host_budget_reserves_outputs_to_completion(self):
+        decode_req = self._new_decode_req("blocked-by-output-reserve", 1)
+        running_req = self._new_decode_req("running", 2).req
+        running_req.kv_committed_len = len(running_req.origin_input_ids)
+        queue = self._new_queue([decode_req])
+        queue.num_reserved_decode_tokens = 2
+        queue.scheduler.running_batch.reqs = [running_req]
+        queue.scheduler.enable_hisparse = True
+        queue.scheduler.hisparse_coordinator = SimpleNamespace(
+            padded_buffer_size=1,
+            compressed_host_len=lambda full_len: full_len,
+            host_decode_reserve_len=lambda full_len, num_decode_tokens: num_decode_tokens,
+            mem_pool_host=SimpleNamespace(available_size=MagicMock(return_value=15)),
+        )
+        queue.token_to_kv_pool_allocator.logical_attn_allocator.available_size.return_value = (
+            100
+        )
+        queue.token_to_kv_pool_allocator.hisparse_attn_allocator.available_size.return_value = (
+            100
+        )
+
+        preallocated, failed = queue.pop_preallocated()
+
+        self.assertEqual(preallocated, [])
+        self.assertEqual(failed, [])
+        queue._pre_alloc.assert_not_called()
+
     def test_failed_request_indices_stay_valid_after_priority_sort(self):
         failed_low = self._new_decode_req("failed-low", 1, failed=True)
         healthy_high = self._new_decode_req("healthy-high", 10)

--- a/test/registered/unit/managers/test_scheduler_output_processor.py
+++ b/test/registered/unit/managers/test_scheduler_output_processor.py
@@ -1,0 +1,122 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+class _FakeMambaPool:
+    def __init__(self):
+        self.freed_indices = []
+
+    def free(self, indices):
+        self.freed_indices.append(indices.clone())
+
+
+class TestSchedulerOutputProcessorFinishedReq(unittest.TestCase):
+    def _new_scheduler(self, tree_cache):
+        scheduler = SimpleNamespace()
+        scheduler.server_args = SimpleNamespace(
+            disaggregation_decode_enable_offload_kvcache=False,
+            enable_hisparse=False,
+        )
+        scheduler.tree_cache = tree_cache
+        scheduler.model_worker = SimpleNamespace()
+        scheduler._mamba_prefix_cache_update = MagicMock()
+        scheduler._maybe_collect_routed_experts = MagicMock()
+        scheduler._maybe_collect_indexer_topk = MagicMock()
+        scheduler._maybe_collect_customized_info = MagicMock()
+        return scheduler
+
+    def _new_finished_req(self, *, req_pool_idx, mamba_pool_idx=None):
+        req = SimpleNamespace()
+        req.rid = "finished-req"
+        req.req_pool_idx = req_pool_idx
+        req.mamba_pool_idx = mamba_pool_idx
+        req.multimodal_inputs = None
+        req.session = None
+        req.kv_committed_freed = False
+        req.kv_overallocated_freed = False
+        req.time_stats = SimpleNamespace(set_completion_time=MagicMock())
+        req.finished = MagicMock(return_value=True)
+        return req
+
+    def _handle_req(self, scheduler, req):
+        with patch(
+            "sglang.srt.managers.scheduler_components.batch_result_processor.get_global_server_args",
+            return_value=SimpleNamespace(enable_mamba_extra_buffer_lazy=lambda: False),
+        ):
+            SchedulerBatchResultProcessor._handle_finish_state_updated_req(
+                scheduler,
+                req,
+                batch=SimpleNamespace(),
+                result=SimpleNamespace(),
+                i=0,
+                logits_output=None,
+            )
+
+    def test_finished_req_without_req_pool_idx_releases_mamba_slot(self):
+        mamba_pool = _FakeMambaPool()
+        tree_cache = SimpleNamespace(
+            supports_mamba=MagicMock(return_value=True),
+            req_to_token_pool=SimpleNamespace(mamba_allocator=mamba_pool),
+        )
+        scheduler = self._new_scheduler(tree_cache)
+        req = self._new_finished_req(
+            req_pool_idx=None, mamba_pool_idx=torch.tensor(7, dtype=torch.int64)
+        )
+
+        self._handle_req(scheduler, req)
+
+        self.assertIsNone(req.mamba_pool_idx)
+        self.assertEqual(len(mamba_pool.freed_indices), 1)
+        torch.testing.assert_close(
+            mamba_pool.freed_indices[0], torch.tensor([7], dtype=torch.int64)
+        )
+        tree_cache.supports_mamba.assert_called_once()
+        req.time_stats.set_completion_time.assert_called_once()
+
+    def test_finished_req_without_any_pool_idx_keeps_duplicate_kv_release_guard(self):
+        tree_cache = SimpleNamespace(supports_mamba=MagicMock(return_value=True))
+        scheduler = self._new_scheduler(tree_cache)
+        req = self._new_finished_req(req_pool_idx=None, mamba_pool_idx=None)
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.batch_result_processor.release_kv_cache"
+        ) as release_kv_cache:
+            self._handle_req(scheduler, req)
+
+        release_kv_cache.assert_not_called()
+        tree_cache.supports_mamba.assert_not_called()
+        req.time_stats.set_completion_time.assert_called_once()
+
+    def test_finished_req_with_req_pool_idx_uses_existing_release_path(self):
+        tree_cache = MagicMock()
+        scheduler = self._new_scheduler(tree_cache)
+        scheduler.server_args.enable_hisparse = True
+        scheduler.hisparse_coordinator = SimpleNamespace(request_finished=MagicMock())
+        req = self._new_finished_req(req_pool_idx=3)
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.batch_result_processor.release_kv_cache"
+        ) as release_kv_cache:
+            self._handle_req(scheduler, req)
+
+        scheduler.hisparse_coordinator.request_finished.assert_called_once_with(req)
+        release_kv_cache.assert_called_once_with(req, tree_cache, is_insert=True)
+        req.time_stats.set_completion_time.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -799,6 +799,49 @@ class TestAdaptiveSpecArgs(CustomTestCase):
         self.assertEqual(args.speculative_num_draft_tokens, 4)
 
 
+class TestHiSparseMTPServerArgs(unittest.TestCase):
+    def _make_hisparse_mtp_args(self, **overrides) -> ServerArgs:
+        args = ServerArgs(model_path="dummy")
+        args.served_model_name = "dummy"
+        args.enable_hisparse = True
+        args.disable_radix_cache = True
+        args.speculative_algorithm = "EAGLE"
+        args.speculative_num_draft_tokens = 4
+        args.speculative_eagle_topk = 1
+        args.enable_mixed_chunk = False
+        args.hisparse_config = '{"top_k": 128}'
+        args.kv_cache_dtype = "bfloat16"
+        args.nsa_prefill_backend = "flashmla_sparse"
+        args.nsa_decode_backend = "flashmla_sparse"
+        args.page_size = 1
+        args.chunked_prefill_size = -1
+        args.enable_grpc = False
+        args.grpc_port = None
+        args.model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(
+                architectures=["GlmMoeDsaForCausalLM"],
+                index_topk=128,
+            )
+        )
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
+    def test_missing_hisparse_page_size_uses_default_capacity(self):
+        args = self._make_hisparse_mtp_args()
+
+        args.check_server_args()
+
+    def test_explicit_small_hisparse_page_size_still_rejects_draft_tokens(self):
+        args = self._make_hisparse_mtp_args(hisparse_config='{"page_size": 4}')
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "hiSparse extra page capacity \\(3 slots\\) is insufficient",
+        ):
+            args.check_server_args()
+
+
 class TestDeepEPWaterfillArgs(CustomTestCase):
     def test_waterfill_enforces_shared_experts_fusion(self):
         server_args = ServerArgs(


### PR DESCRIPTION
## Summary

Cherry-pick the HiSparse MTP/speculative decoding without H2D follow-up changes onto `pr2ybyang/hisparse-mtp-without-h2d-based-on-glm52`.

This PR brings in 5 commits from `fea/hisparse-mtp-without-h2d` after `8d5ed330cc99d5b37325a9dd175f4cb8554de3f3`.

The target branch was at `8415a33601` before the rebase work and is now updated to `47f480ef72`.

## Changes

- Add HiSparse MTP/speculative decoding support with extra-page draft zones.
- Fix HiSparse MTP draft KV mapping across draft/verify paths.
- Fix PD decode retract behavior for HiSparse by avoiding the unsupported `get_cpu_copy()` path.
- Fix HiSparse host-pool budgeting and Mooncake cleanup paths.
- Release leftover Mamba slots when finished requests no longer have `req_pool_idx`.

## Cherry-picked Commits

- `5917d1f25` -> `c0171dc3df`: `[Feature] Support MTP/speculative decoding with hiSparse extra page draft zone`
- `491c1e7fd` -> `d68f14f7f2`: `fix: 修复 HiSparse MTP draft KV 映射`
- `885400408` -> `f93bc907a5`: `fix: 修复 PD decode 节点 HiSparse retract 时 get_cpu_copy 未实现导致崩溃`
- `ba4db93b0` -> `2dff36907e`: `fix: 修复 HiSparse host pool 预算和 Mooncake 收尾`
- `5adb89d4f` -> `47f480ef72`: `fix: 清理 req_pool_idx 为空时的 Mamba cache`

## Conflict Resolution Notes

Conflicts were resolved by preserving the current glm52 branch structure and porting the source branch changes into the corresponding files.

- `python/sglang/srt/layers/attention/dsa_backend.py`
- Kept the target branch's DSA backend shape and moved the HiSparse draft-zone logic into it.
- Preserved the target branch's NSA compatibility shim instead of restoring the older source layout.
- `python/sglang/srt/model_executor/forward_batch_info.py`
- Added `hisparse_coordinator` propagation while keeping the target branch's existing forward metadata fields.
- `python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py`
- `python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py`
- Preserved the target branch's `init_forward_metadata_out_graph` handling and carried over the draft KV mapping fixes.
- `python/sglang/srt/disaggregation/decode.py`
- `python/sglang/srt/managers/hisparse_coordinator.py`
- `python/sglang/srt/mem_cache/hisparse_memory_pool.py`
- Ported the HiSparse retract fix to the target paged host-pool APIs, avoiding the unsupported CPU-copy path on PD decode nodes.
- `python/sglang/srt/disaggregation/mooncake/conn.py`
- `python/sglang/srt/disaggregation/prefill.py`
- Ported host-pool budget checks and Mooncake cleanup while preserving glm52's current PD/HiCache behavior.
- `python/sglang/srt/managers/scheduler_components/batch_result_processor.py`
- Moved the finished-request Mamba cache cleanup from the removed old scheduler output mixin into the target branch's scheduler component.
- Kept `python/sglang/srt/managers/scheduler_output_processor_mixin.py` deleted.

## Testing

- `uv run python -m py_compile` on changed Python files
- `uv run python -m pytest test/registered/unit/disaggregation/test_prefill_bootstrap_admission.py`
- `uv run python -m pytest test/registered/unit/managers/test_priority_scheduling_disaggregation.py`
- `uv run python -m pytest test/registered/unit/managers/test_hisparse_unit.py::test_next_decode_host_budget_counts_only_new_allocations`
- `uv run python -m pytest test/registered/unit/managers/test_scheduler_output_processor.py`
- Pre-commit hooks passed during cherry-pick continuation

Push validation:

- `git push origin pr2ybyang/hisparse-mtp-without-h2d-based-on-glm52`
- `git rev-list --left-right --count origin/pr2ybyang/hisparse-mtp-without-h2d-based-on-glm52...HEAD` returned `0 0`
